### PR TITLE
Mirror bars to all outputs #48

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -21,7 +21,7 @@ config_dir = get_config_dir()
 configs = {}
 editor = None
 selector_window = None
-outputs = None
+outputs = {}
 
 SKELETON_PANEL: dict = {
     "name": "",
@@ -538,7 +538,10 @@ class EditorWrapper(object):
         self.cb_output = builder.get_object("output")
         for key in outputs:
             self.cb_output.append(key, key)
-        if self.panel["output"] and self.panel["output"] in outputs:
+
+        self.cb_output.append("All", "All")
+
+        if self.panel["output"] and (self.panel["output"] in outputs or self.panel["output"] == "All"):
             self.cb_output.set_active_id(self.panel["output"])
 
         screen_width, screen_height = None, None

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -251,6 +251,27 @@ def main():
     except Exception as e:
         print(e)
 
+    # Mirror bars to all outputs #48 (if panel["output"] == "All")
+    to_remove = []
+    to_append = []
+    for panel in panels:
+        check_key(panel, "output", "")
+
+        clones = []
+        if panel["output"] == "All" and len(common.outputs) > 1:
+            to_remove.append(panel)
+            for key in common.outputs.keys():
+                clone = panel.copy()
+                clone["output"] = key
+                clones.append(clone)
+                
+            to_append = to_append + clones
+        
+    for item in to_remove:
+        panels.remove(item)
+        
+    panels = panels + to_append
+
     for panel in panels:
         check_key(panel, "icons", "")
         icons_path = ""
@@ -258,8 +279,6 @@ def main():
             icons_path = os.path.join(common.config_dir, "icons_light")
         elif panel["icons"] == "dark":
             icons_path = os.path.join(common.config_dir, "icons_dark")
-
-        check_key(panel, "output", "")
 
         # This is to allow width "auto" value. Actually all non-numeric values will be removed.
         if "width" in panel and not isinstance(panel["width"], int):
@@ -380,7 +399,7 @@ def main():
 
             check_key(panel, "layer", "top")
             o = panel["output"] if "output" in panel else "undefined"
-            print("Display: {}, position: {}, layer: {}, width: {}, height: {}".format(o, panel["position"],
+            print("Output: {}, position: {}, layer: {}, width: {}, height: {}".format(o, panel["position"],
                                                                                        panel["layer"], panel["width"],
                                                                                        panel["height"]))
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.2.1',
+    version='0.2.2',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Added "All" option to Settings/panel/output to allow cloning the panel window to all detected outputs; resolves #48 