### PR TITLE
Shorten refresh delay so it isn't obvious

### DIFF
--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -470,7 +470,7 @@ def main():
     else:
         common.outputs = list_outputs(sway=sway, tree=tree, silent=True)
         common.outputs_num = len(common.outputs)
-    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 200, check_tree)
+    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 20, check_tree)
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)

--- a/nwg_panel/modules/playerctl.py
+++ b/nwg_panel/modules/playerctl.py
@@ -20,7 +20,7 @@ class Playerctl(Gtk.EventBox):
         self.settings = settings
         self.icons_path = icons_path
         Gtk.EventBox.__init__(self)
-        check_key(settings, "interval", 1)
+        check_key(settings, "interval", 20)
         check_key(settings, "label-css-name", "")
         check_key(settings, "button-css-name", "")
         check_key(settings, "icon-size", 16)
@@ -49,7 +49,7 @@ class Playerctl(Gtk.EventBox):
         self.refresh()
 
         if settings["interval"] > 0:
-            Gdk.threads_add_timeout_seconds(GLib.PRIORITY_LOW, settings["interval"], self.refresh)
+            Gdk.threads_add_timeout(GLib.PRIORITY_LOW, settings["interval"], self.refresh)
 
     def update_widget(self, status, metadata):
         if status in ["Playing", "Paused"]:


### PR DESCRIPTION
More visually pleasing: workspace switch and playerctl changes appear to be instant now.