### PR TITLE
Name root/parent module GTK objects.

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -50,6 +50,7 @@ SKELETON_PANEL: dict = {
         "icon-size": 16,
         "hover-opens": True,
         "leave-closes": True,
+        "root-css-name": "controls-overview",
         "css-name": "controls-window",
         "net-interface": "",
         "custom-items": [{"name": "Panel settings", "icon": "nwg-panel", "cmd": "nwg-panel-config"}],
@@ -105,6 +106,7 @@ SKELETON_PANEL: dict = {
         "on-right-click": "",
         "on-scroll-up": "",
         "on-scroll-down": "",
+        "root-css-name": "root-clock",
         "css-name": "clock",
         "interval": 1
     },
@@ -952,6 +954,7 @@ class EditorWrapper(object):
             "on-right-click": "",
             "on-scroll-up": "",
             "on-scroll-down": "",
+            "root-css-name": "root-clock",
             "css-name": "clock",
             "interval": 1
         }
@@ -982,6 +985,9 @@ class EditorWrapper(object):
         self.eb_on_scroll_down = builder.get_object("on-scroll-down")
         self.eb_on_scroll_down.set_text(settings["on-scroll-down"])
 
+        self.eb_root_css_name_clock = builder.get_object("root-css-name")
+        self.eb_root_css_name_clock.set_text(settings["root-css-name"])
+
         self.eb_css_name_clock = builder.get_object("css-name")
         self.eb_css_name_clock.set_text(settings["css-name"])
 
@@ -1006,6 +1012,7 @@ class EditorWrapper(object):
 
         settings["on-scroll-up"] = self.eb_on_scroll_up.get_text()
         settings["on-scroll-down"] = self.eb_on_scroll_down.get_text()
+        settings["root-css-name"] = self.eb_root_css_name_clock.get_text()
         settings["css-name"] = self.eb_css_name_clock.get_text()
 
         val = self.sb_interval.get_value()
@@ -1400,6 +1407,7 @@ class EditorWrapper(object):
             "on-right-click": "",
             "on-scroll-up": "",
             "on-scroll-down": "",
+            "root-css-name": "",
             "css-name": "",
             "icon-placement": "left",
             "icon-size": 16,
@@ -1435,6 +1443,9 @@ class EditorWrapper(object):
 
         self.executor_on_scroll_down = builder.get_object("on-scroll-down")
         self.executor_on_scroll_down.set_text(settings["on-scroll-down"])
+
+        self.executor_root_css_name = builder.get_object("root-css-name")
+        self.executor_root_css_name.set_text(settings["root-css-name"])
 
         self.executor_css_name = builder.get_object("css-name")
         self.executor_css_name.set_text(settings["css-name"])
@@ -1473,6 +1484,7 @@ class EditorWrapper(object):
             settings["on-right-click"] = self.executor_on_right_click.get_text()
             settings["on-scroll-up"] = self.executor_on_scroll_up.get_text()
             settings["on-scroll-down"] = self.executor_on_scroll_down.get_text()
+            settings["root-css-name"] = self.executor_root_css_name.get_text()
             settings["css-name"] = self.executor_css_name.get_text()
             val = self.executor_icon_placement.get_active_id()
             if val:
@@ -1784,6 +1796,7 @@ class EditorWrapper(object):
             "icon-size": 16,
             "hover-opens": True,
             "leave-closes": True,
+            "root-css-name": "controls-overview",
             "css-name": "controls-window",
             "net-interface": "",
             "custom-items": [
@@ -1855,6 +1868,9 @@ class EditorWrapper(object):
         self.ctrl_cdm_battery = builder.get_object("ctrl-cmd-battery")
         check_key(settings["commands"], "battery", "")
         self.ctrl_cdm_battery.set_text(settings["commands"]["battery"])
+
+        self.ctrl_root_css_name = builder.get_object("root-css-name")
+        self.ctrl_root_css_name.set_text(settings["root-css-name"])
 
         self.ctrl_css_name = builder.get_object("css-name")
         self.ctrl_css_name.set_text(settings["css-name"])
@@ -1940,6 +1956,7 @@ class EditorWrapper(object):
         settings["net-interface"] = self.ctrl_net_name.get_text()
         settings["commands"]["bluetooth"] = self.ctrl_cdm_bluetooth.get_text()
         settings["commands"]["battery"] = self.ctrl_cdm_battery.get_text()
+        settings["root-css-name"] = self.ctrl_root_css_name.get_text()
         settings["css-name"] = self.ctrl_css_name.get_text()
 
         settings["window-width"] = int(self.ctrl_window_width.get_value())

--- a/nwg_panel/glade/config_clock.glade
+++ b/nwg_panel/glade/config_clock.glade
@@ -6,8 +6,8 @@
   <object class="GtkGrid" id="grid">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="row-spacing">10</property>
-    <property name="column-spacing">10</property>
+    <property name="row-spacing">12</property>
+    <property name="column-spacing">12</property>
     <child>
       <object class="GtkLabel">
         <property name="visible">True</property>
@@ -17,7 +17,7 @@
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">9</property>
+        <property name="top-attach">10</property>
       </packing>
     </child>
     <child>
@@ -27,11 +27,33 @@
       </object>
       <packing>
         <property name="left-attach">1</property>
-        <property name="top-attach">9</property>
+        <property name="top-attach">10</property>
       </packing>
     </child>
     <child>
       <object class="GtkEntry" id="css-name">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">9</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">CSS name</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">9</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="root-css-name">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
       </object>
@@ -45,7 +67,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">CSS name</property>
+        <property name="label" translatable="yes">Root CSS name</property>
       </object>
       <packing>
         <property name="left-attach">0</property>

--- a/nwg_panel/glade/config_controls.glade
+++ b/nwg_panel/glade/config_controls.glade
@@ -6,10 +6,33 @@
   <object class="GtkGrid" id="grid">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="row-spacing">10</property>
-    <property name="column-spacing">10</property>
+    <property name="row-spacing">12</property>
+    <property name="column-spacing">12</property>
     <child>
       <object class="GtkEntry" id="css-name">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="width-chars">12</property>
+      </object>
+      <packing>
+        <property name="left-attach">2</property>
+        <property name="top-attach">7</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">CSS name</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">7</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="root-css-name">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="width-chars">12</property>
@@ -24,7 +47,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">CSS name</property>
+        <property name="label" translatable="yes">Root CSS name</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
@@ -237,7 +260,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">7</property>
+        <property name="top-attach">8</property>
       </packing>
     </child>
     <child>
@@ -250,7 +273,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">3</property>
-        <property name="top-attach">7</property>
+        <property name="top-attach">8</property>
       </packing>
     </child>
     <child>
@@ -260,7 +283,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">2</property>
-        <property name="top-attach">7</property>
+        <property name="top-attach">8</property>
       </packing>
     </child>
     <child>
@@ -326,7 +349,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">11</property>
+        <property name="top-attach">12</property>
         <property name="width">4</property>
       </packing>
     </child>
@@ -337,7 +360,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">2</property>
-        <property name="top-attach">10</property>
+        <property name="top-attach">11</property>
       </packing>
     </child>
     <child>
@@ -349,7 +372,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">10</property>
+        <property name="top-attach">11</property>
       </packing>
     </child>
     <child>
@@ -359,7 +382,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">2</property>
-        <property name="top-attach">9</property>
+        <property name="top-attach">10</property>
       </packing>
     </child>
     <child>
@@ -371,7 +394,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">9</property>
+        <property name="top-attach">10</property>
       </packing>
     </child>
     <child>
@@ -382,7 +405,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">8</property>
+        <property name="top-attach">9</property>
       </packing>
     </child>
     <child>
@@ -392,7 +415,7 @@ Depends on `python-netifaces`.</property>
       </object>
       <packing>
         <property name="left-attach">2</property>
-        <property name="top-attach">8</property>
+        <property name="top-attach">9</property>
       </packing>
     </child>
     <child>

--- a/nwg_panel/glade/config_executor.glade
+++ b/nwg_panel/glade/config_executor.glade
@@ -6,10 +6,32 @@
   <object class="GtkGrid" id="grid">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
-    <property name="row-spacing">10</property>
-    <property name="column-spacing">10</property>
+    <property name="row-spacing">12</property>
+    <property name="column-spacing">12</property>
     <child>
       <object class="GtkEntry" id="css-name">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">10</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">CSS name</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">10</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="root-css-name">
         <property name="visible">True</property>
         <property name="can-focus">True</property>
       </object>
@@ -23,7 +45,7 @@
         <property name="visible">True</property>
         <property name="can-focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes">CSS name</property>
+        <property name="label" translatable="yes">Root CSS name</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
@@ -282,7 +304,7 @@ executor will create a new one.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">13</property>
+        <property name="top-attach">14</property>
         <property name="width">2</property>
       </packing>
     </child>
@@ -293,7 +315,7 @@ executor will create a new one.</property>
       </object>
       <packing>
         <property name="left-attach">1</property>
-        <property name="top-attach">12</property>
+        <property name="top-attach">13</property>
       </packing>
     </child>
     <child>
@@ -305,7 +327,7 @@ executor will create a new one.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">12</property>
+        <property name="top-attach">13</property>
       </packing>
     </child>
     <child>
@@ -317,7 +339,7 @@ executor will create a new one.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">11</property>
+        <property name="top-attach">12</property>
       </packing>
     </child>
     <child>
@@ -327,7 +349,7 @@ executor will create a new one.</property>
       </object>
       <packing>
         <property name="left-attach">1</property>
-        <property name="top-attach">11</property>
+        <property name="top-attach">12</property>
       </packing>
     </child>
     <child>
@@ -339,7 +361,7 @@ executor will create a new one.</property>
       </object>
       <packing>
         <property name="left-attach">0</property>
-        <property name="top-attach">10</property>
+        <property name="top-attach">11</property>
       </packing>
     </child>
     <child>
@@ -353,7 +375,7 @@ executor will create a new one.</property>
       </object>
       <packing>
         <property name="left-attach">1</property>
-        <property name="top-attach">10</property>
+        <property name="top-attach">11</property>
       </packing>
     </child>
     <child>

--- a/nwg_panel/modules/clock.py
+++ b/nwg_panel/modules/clock.py
@@ -24,6 +24,7 @@ class Clock(Gtk.EventBox):
         self.add(self.box)
         self.label = Gtk.Label("")
 
+        check_key(settings, "root-css-name", "root-clock")
         check_key(settings, "css-name", "clock")
         check_key(settings, "tooltip-text", "")
         check_key(settings, "on-left-click", "")
@@ -34,9 +35,8 @@ class Clock(Gtk.EventBox):
 
         check_key(settings, "interval", 1)
 
-        if "css-name" in settings:
-            self.set_property("name", "root-" + settings["css-name"])
-            self.label.set_property("name", settings["css-name"])
+        self.set_property("name", settings["root-css-name"])
+        self.label.set_property("name", settings["css-name"])
 
         if settings["tooltip-text"]:
             self.set_tooltip_text(settings["tooltip-text"])

--- a/nwg_panel/modules/clock.py
+++ b/nwg_panel/modules/clock.py
@@ -35,6 +35,7 @@ class Clock(Gtk.EventBox):
         check_key(settings, "interval", 1)
 
         if "css-name" in settings:
+            self.set_property("name", "root-" + settings["css-name"])
             self.label.set_property("name", settings["css-name"])
 
         if settings["tooltip-text"]:

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -30,11 +30,11 @@ class Controls(Gtk.EventBox):
         check_key(settings, "icon-size", 16)
         check_key(settings, "hover-opens", True)
         check_key(settings, "leave-closes", True)
-        check_key(settings, "css-name", "controls-label")
+        check_key(settings, "root-css-name", "controls-overview")
         check_key(settings, "components", ["net", "brightness", "volume", "battery"])
         check_key(settings, "net-interface", "")
 
-        self.set_property("name", "controls-label")
+        self.set_property("name", settings["root-css-name"])
 
         self.icon_size = settings["icon-size"]
 

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -34,6 +34,8 @@ class Controls(Gtk.EventBox):
         check_key(settings, "components", ["net", "brightness", "volume", "battery"])
         check_key(settings, "net-interface", "")
 
+        self.set_property("name", "controls-label")
+
         self.icon_size = settings["icon-size"]
 
         self.net_icon_name = "view-refresh-symbolic"

--- a/nwg_panel/modules/cpu_avg.py
+++ b/nwg_panel/modules/cpu_avg.py
@@ -20,6 +20,9 @@ class CpuAvg(Gtk.EventBox):
         Gtk.EventBox.__init__(self)
         self.box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         self.add(self.box)
+
+        self.set_property("name", "root-executor")
+
         self.label = Gtk.Label()
         self.label.set_property("name", "executor-label")
 

--- a/nwg_panel/modules/cpu_avg.py
+++ b/nwg_panel/modules/cpu_avg.py
@@ -20,9 +20,6 @@ class CpuAvg(Gtk.EventBox):
         Gtk.EventBox.__init__(self)
         self.box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         self.add(self.box)
-
-        self.set_property("name", "root-executor")
-
         self.label = Gtk.Label()
         self.label.set_property("name", "executor-label")
 

--- a/nwg_panel/modules/executor.py
+++ b/nwg_panel/modules/executor.py
@@ -41,8 +41,10 @@ class Executor(Gtk.EventBox):
         update_image(self.image, "view-refresh-symbolic", self.settings["icon-size"], self.icons_path)
 
         if settings["css-name"]:
+            self.set_property("name", "root-" + settings["css-name"])
             self.label.set_property("name", settings["css-name"])
         else:
+            self.set_property("name", "root-executor")
             self.label.set_property("name", "executor-label")
 
         if settings["tooltip-text"]:

--- a/nwg_panel/modules/executor.py
+++ b/nwg_panel/modules/executor.py
@@ -28,7 +28,8 @@ class Executor(Gtk.EventBox):
 
         check_key(settings, "script", "")
         check_key(settings, "interval", 0)
-        check_key(settings, "css-name", "")
+        check_key(settings, "root-css-name", "root-executor")
+        check_key(settings, "css-name", "executor-label")
         check_key(settings, "icon-placement", "left")
         check_key(settings, "icon-size", 16)
         check_key(settings, "tooltip-text", "")
@@ -40,12 +41,8 @@ class Executor(Gtk.EventBox):
 
         update_image(self.image, "view-refresh-symbolic", self.settings["icon-size"], self.icons_path)
 
-        if settings["css-name"]:
-            self.set_property("name", "root-" + settings["css-name"])
-            self.label.set_property("name", settings["css-name"])
-        else:
-            self.set_property("name", "root-executor")
-            self.label.set_property("name", "executor-label")
+        self.set_property("name", settings["root-css-name"])
+        self.label.set_property("name", settings["css-name"])
 
         if settings["tooltip-text"]:
             self.set_tooltip_text(settings["tooltip-text"])


### PR DESCRIPTION
This allows the modules root object (the module object directly inheriting a GTK object) to be referenced in CSS (as 'root-' and whatever CSS name was configured for that module).