### PR TITLE
Fix crashes on empty or wrong icon name

### DIFF
--- a/nwg_panel/modules/executor.py
+++ b/nwg_panel/modules/executor.py
@@ -29,7 +29,7 @@ class Executor(Gtk.EventBox):
         check_key(settings, "script", "")
         check_key(settings, "interval", 0)
         check_key(settings, "root-css-name", "root-executor")
-        check_key(settings, "css-name", "executor-label")
+        check_key(settings, "css-name", "")
         check_key(settings, "icon-placement", "left")
         check_key(settings, "icon-size", 16)
         check_key(settings, "tooltip-text", "")
@@ -42,7 +42,12 @@ class Executor(Gtk.EventBox):
         update_image(self.image, "view-refresh-symbolic", self.settings["icon-size"], self.icons_path)
 
         self.set_property("name", settings["root-css-name"])
-        self.label.set_property("name", settings["css-name"])
+
+        # reverting #57, as check_key only adds keys if MISSING, not if empty
+        if settings["css-name"]:
+            self.label.set_property("name", settings["css-name"])
+        else:
+            self.label.set_property("name", "executor-label")
 
         if settings["tooltip-text"]:
             self.set_tooltip_text(settings["tooltip-text"])

--- a/nwg_panel/modules/sway_taskbar.py
+++ b/nwg_panel/modules/sway_taskbar.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
+import os
 from gi.repository import Gtk, Gdk, GdkPixbuf
 
-from nwg_panel.tools import check_key, get_icon, update_image, load_autotiling
+from nwg_panel.tools import check_key, get_icon, update_image, load_autotiling, get_config_dir
 import nwg_panel.common
 
 
@@ -131,8 +132,12 @@ class WindowBox(Gtk.EventBox):
                     image = Gtk.Image()
                     update_image(image, icon_from_desktop, settings["image-size"], icons_path)
                 else:
-                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_from_desktop, settings["image-size"],
+                    try:
+                        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_from_desktop, settings["image-size"],
                                                                     settings["image-size"])
+                    except:
+                        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(
+                            os.path.join(get_config_dir(), "icons_light/icon-missing.svg"), settings["image-size"], settings["image-size"])
                     image = Gtk.Image.new_from_pixbuf(pixbuf)
 
                 self.box.pack_start(image, False, False, 4)

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -485,8 +485,11 @@ def update_image(image, icon_name, icon_size, icons_path=""):
             try:
                 pixbuf = icon_theme.load_icon(icon_name, icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
             except:
-                path = os.path.join(get_config_dir(), "icons_light/icon-missing.svg")
-                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, icon_size, icon_size)
+                try:
+                    pixbuf = icon_theme.load_icon(icon_name.lower(), icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
+                except:
+                    path = os.path.join(get_config_dir(), "icons_light/icon-missing.svg")
+                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, icon_size, icon_size)
             if image:
                 image.set_from_pixbuf(pixbuf)
 

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -75,6 +75,8 @@ def get_app_dirs():
 
 
 def get_icon(app_name):
+    if not app_name:
+        return ""
     # GIMP returns "app_id": null and for some reason "class": "Gimp-2.10" instead of just "gimp".
     # Until the GTK3 version is released, let's make an exception for GIMP.
     if "GIMP" in app_name.upper():
@@ -456,7 +458,7 @@ def player_metadata():
 
 def update_image(image, icon_name, icon_size, icons_path=""):
     # In case a full path was given
-    if icon_name.startswith("/"):
+    if icon_name and icon_name.startswith("/"):
         try:
             pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_name, icon_size, icon_size)
             image.set_from_pixbuf(pixbuf)


### PR DESCRIPTION
fixes #58
fixes #59
reverts regression from #57 (missing default `executor-label` value in `settings["css-name"]` in executor module)