### PR TITLE
Map "reverse DNS"-style named .desktop file names to relevant icon names

### DIFF
--- a/nwg_panel/common.py
+++ b/nwg_panel/common.py
@@ -16,6 +16,7 @@ workspaces_list = []
 controls_list = []
 config_dir = ""
 app_dirs = []
+name2icon_dict = {}
 
 commands = {
     "light": False,

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -239,6 +239,7 @@ def main():
     save_string("-c {} -s {}".format(args.config, args.style), os.path.join(local_dir(), "args"))
 
     common.app_dirs = get_app_dirs()
+    common.name2icon_dict = map_odd_desktop_files()
 
     config_file = os.path.join(common.config_dir, args.config)
 

--- a/nwg_panel/modules/scratchpad.py
+++ b/nwg_panel/modules/scratchpad.py
@@ -6,7 +6,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
-from nwg_panel.tools import check_key, get_icon, update_image
+from nwg_panel.tools import check_key, get_icon_name, update_image
 
 
 class Scratchpad(Gtk.Box):
@@ -36,9 +36,9 @@ class Scratchpad(Gtk.Box):
             if aid:
                 pid = node.pid
                 if node.app_id:
-                    icon = get_icon(node.app_id)
+                    icon = get_icon_name(node.app_id)
                 elif node.window_class:
-                    icon = get_icon(node.window_class)
+                    icon = get_icon_name(node.window_class)
                 else:
                     icon = "icon-missing"
 

--- a/nwg_panel/modules/sway_workspaces.py
+++ b/nwg_panel/modules/sway_workspaces.py
@@ -3,7 +3,7 @@
 from gi.repository import Gtk, GdkPixbuf
 
 import nwg_panel.common
-from nwg_panel.tools import check_key, get_icon, update_image,load_autotiling
+from nwg_panel.tools import check_key, get_icon_name, update_image,load_autotiling
 
 
 class SwayWorkspaces(Gtk.Box):
@@ -130,7 +130,7 @@ class SwayWorkspaces(Gtk.Box):
     
     def update_icon(self, win_id, win_name):
         if win_id and win_name:
-            icon_from_desktop = get_icon(win_id)
+            icon_from_desktop = get_icon_name(win_id)
             if icon_from_desktop:
                 if "/" not in icon_from_desktop and not icon_from_desktop.endswith(
                         ".svg") and not icon_from_desktop.endswith(".png"):

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -97,9 +97,9 @@ def get_icon_name(app_name):
         # Search .desktop files that use "reverse DNS"-style names
         # see: https://github.com/nwg-piotr/nwg-panel/issues/64
         elif os.path.isdir(d):
-            for path in os.listdir(d):
-                if os.path.isfile(path) and app_name.lower() in path.lower().split("."):
-                    content = load_text_file(os.path.join(d, path))
+            for filename in os.listdir(d):
+                if os.path.isfile(os.path.join(d, filename)) and app_name.lower() in filename.lower().split("."):
+                    content = load_text_file(os.path.join(d, filename))
                     if content:
                         for line in content.splitlines():
                             if line.upper().startswith("ICON"):

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -8,7 +8,7 @@ import stat
 
 import gi
 
-import common
+import nwg_panel.common
 
 gi.require_version('GdkPixbuf', '2.0')
 gi.require_version('Gtk', '3.0')

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -98,7 +98,7 @@ def get_icon_name(app_name):
         # See: https://github.com/nwg-piotr/nwg-panel/issues/64
         elif os.path.isdir(d):
             for file in os.listdir(d):
-                if app_name in file.split("."):
+                if app_name.lower() in file.lower().split("."):
                     content = load_text_file(os.path.join(d, file))
                     for line in content.splitlines():
                         if line.upper().startswith("ICON"):

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -74,7 +74,7 @@ def get_app_dirs():
     return desktop_dirs
 
 
-def get_icon(app_name):
+def get_icon_name(app_name):
     if not app_name:
         return ""
     # GIMP returns "app_id": null and for some reason "class": "Gimp-2.10" instead of just "gimp".
@@ -83,6 +83,7 @@ def get_icon(app_name):
         return "gimp"
 
     for d in nwg_panel.common.app_dirs:
+        # This will work if the .desktop file name is app_id.desktop or wm_class.desktop
         path = os.path.join(d, "{}.desktop".format(app_name))
         content = None
         if os.path.isfile(path):
@@ -93,6 +94,15 @@ def get_icon(app_name):
             for line in content.splitlines():
                 if line.upper().startswith("ICON"):
                     return line.split("=")[1]
+        # Support for "reverse DNS" .desktop file names
+        # See: https://github.com/nwg-piotr/nwg-panel/issues/64
+        elif os.path.isdir(d):
+            for file in os.listdir(d):
+                if app_name in file.split("."):
+                    content = load_text_file(os.path.join(d, file))
+                    for line in content.splitlines():
+                        if line.upper().startswith("ICON"):
+                            return line.split("=")[1]
 
 
 def local_dir():

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -94,15 +94,16 @@ def get_icon_name(app_name):
             for line in content.splitlines():
                 if line.upper().startswith("ICON"):
                     return line.split("=")[1]
-        # Support for "reverse DNS" .desktop file names
-        # See: https://github.com/nwg-piotr/nwg-panel/issues/64
+        # Search .desktop files that use "reverse DNS"-style names
+        # see: https://github.com/nwg-piotr/nwg-panel/issues/64
         elif os.path.isdir(d):
-            for file in os.listdir(d):
-                if app_name.lower() in file.lower().split("."):
-                    content = load_text_file(os.path.join(d, file))
-                    for line in content.splitlines():
-                        if line.upper().startswith("ICON"):
-                            return line.split("=")[1]
+            for path in os.listdir(d):
+                if os.path.isfile(path) and app_name.lower() in path.lower().split("."):
+                    content = load_text_file(os.path.join(d, path))
+                    if content:
+                        for line in content.splitlines():
+                            if line.upper().startswith("ICON"):
+                                return line.split("=")[1]
 
 
 def local_dir():

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.4.0',
+    version='0.4.1',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Map "reverse DNS"-style named .desktop file names to relevant icon names on panel startup. If no icon found in GTK theme for certain app_id/wm_class, the dictionary will be searched for occurence of the latter. If name found in keys, the assigned icon will be used. Closes #64