### PR TITLE
Alternatives

### DIFF
--- a/nwg_panel/common.py
+++ b/nwg_panel/common.py
@@ -28,7 +28,8 @@ commands = {
     "playerctl": False,
     "netifaces": False,
     "pybluez": False,
-    "wlr-randr": False
+    "wlr-randr": False,
+    "upower": False
 }
 
 icons_path = ""  # "icons_light", "icons_dark" or "" (GTK icons)

--- a/nwg_panel/common.py
+++ b/nwg_panel/common.py
@@ -22,6 +22,7 @@ name2icon_dict = {}
 
 commands = {
     "light": False,
+    "brightnessctl": False,
     "pamixer": False,
     "pactl": False,
     "playerctl": False,

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -741,18 +741,18 @@ def vol_icon_name(value, muted):
 def bat_icon_name(value, is_charging):
     icon_name = "battery-empty-symbolic"
     if is_charging:
-        if value > 95:
+        if value > 90:
             icon_name = "battery-full-charging-symbolic"
-        elif value > 50:
+        elif value > 40:
             icon_name = "battery-good-charging-symbolic"
-        elif value > 20:
+        elif value > 19:
             icon_name = "battery-low-charging-symbolic"
     else:
-        if value > 95:
+        if value > 90:
             icon_name = "battery-full-symbolic"
-        elif value > 50:
+        elif value > 40:
             icon_name = "battery-good-symbolic"
-        elif value > 20:
+        elif value > 19:
             icon_name = "battery-low-symbolic"
 
     return icon_name

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -422,8 +422,15 @@ def get_brightness():
             brightness = int(round(float(output), 0))
         except:
             pass
+    elif nwg_panel.common.commands["brightnessctl"]:
+        try:
+            output = cmd2string("brightnessctl g")
+            b = int(output) * 100 / 255
+            brightness = int(round(float(b), 0))
+        except:
+            pass
     else:
-        eprint("Couldn't get brightness, 'light' not found")
+        eprint("Couldn't get brightness, is 'light' or 'brightnessctl' installed?")
 
     return brightness
 
@@ -434,8 +441,12 @@ def set_brightness(slider):
         value = 1
     if nwg_panel.common.commands["light"]:
         subprocess.call("{} {}".format("light -S", value).split())
+    elif nwg_panel.common.commands["brightnessctl"]:
+        subprocess.call("{} {}%".format("brightnessctl s", value).split(),
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.STDOUT)
     else:
-        eprint("Required 'light' command not found")
+        eprint("Either 'light' or 'brightnessctl' package required")
 
 
 def get_battery():

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.5.0',
+    version='0.5.1',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- support for `brightnessctl` as the `light` package alternative
- `upower` as fallback battery check (where `psutil` doesn't work)
- changed assignment battery level -> icon