### PR TITLE
bluez-utils instead of python-pybluez #72

### DIFF
--- a/nwg_panel/common.py
+++ b/nwg_panel/common.py
@@ -28,6 +28,7 @@ commands = {
     "playerctl": False,
     "netifaces": False,
     "pybluez": False,
+    "btmgmt": False,
     "wlr-randr": False,
     "upower": False
 }

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -1903,7 +1903,11 @@ class EditorWrapper(object):
         self.ctrl_comp_net.set_active("net" in settings["components"])
 
         self.ctrl_comp_bluetooth = builder.get_object("ctrl-comp-bluetooth")
-        self.ctrl_comp_bluetooth.set_active("bluetooth" in settings["components"])
+        if is_command("btmgmt"):
+            self.ctrl_comp_bluetooth.set_active("bluetooth" in settings["components"])
+        else:
+            self.ctrl_comp_bluetooth.set_active(False)
+            self.ctrl_comp_bluetooth.set_sensitive(False)
 
         self.ctrl_comp_battery = builder.get_object("ctrl-comp-battery")
         self.ctrl_comp_battery.set_active("battery" in settings["components"])

--- a/nwg_panel/glade/config_controls.glade
+++ b/nwg_panel/glade/config_controls.glade
@@ -2,7 +2,7 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
-  <!-- n-columns=4 n-rows=12 -->
+  <!-- n-columns=4 n-rows=13 -->
   <object class="GtkGrid" id="grid">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -107,8 +107,7 @@
       <object class="GtkImage">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="tooltip-text" translatable="yes">Depends on `python-pybluez`
-(python3-bluez / p3-bluez).</property>
+        <property name="tooltip-text" translatable="yes">Depends on `bluez-utils`.</property>
         <property name="halign">start</property>
         <property name="stock">gtk-about</property>
       </object>
@@ -215,7 +214,7 @@ Depends on `python-netifaces`.</property>
       <object class="GtkImage">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="tooltip-text" translatable="yes">Depends on the `light` package.</property>
+        <property name="tooltip-text" translatable="yes">Depends on `light` or `brightnessctl`.</property>
         <property name="halign">start</property>
         <property name="stock">gtk-about</property>
       </object>
@@ -417,6 +416,12 @@ Depends on `python-netifaces`.</property>
         <property name="left-attach">2</property>
         <property name="top-attach">9</property>
       </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <placeholder/>
     </child>
     <child>
       <placeholder/>

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -11,7 +11,7 @@ gi.require_version('GtkLayerShell', '0.1')
 from gi.repository import Gtk, Gdk, GLib, GtkLayerShell
 
 from nwg_panel.tools import check_key, get_brightness, set_brightness, get_volume, set_volume, get_battery, \
-    get_interface, update_image, bt_adr, eprint, list_sinks, toggle_mute
+    get_interface, update_image, bt_info, eprint, list_sinks, toggle_mute
 
 from nwg_panel.common import commands
 
@@ -130,10 +130,10 @@ class Controls(Gtk.EventBox):
             self.net_ip_addr = get_interface(self.settings["net-interface"])
             GLib.idle_add(self.update_net, self.net_ip_addr)
 
-        if commands["pybluez"]:
-            adr = bt_adr()
+        if commands["btmgmt"]:
+            name, powered = bt_info()
             if "bluetooth" in self.settings["components"]:
-                GLib.idle_add(self.update_bt, adr)
+                GLib.idle_add(self.update_bt, name, powered)
 
         if "brightness" in self.settings["components"]:
             try:
@@ -180,15 +180,15 @@ class Controls(Gtk.EventBox):
         if self.net_label:
             self.net_label.set_text("{}".format(self.settings["net-interface"]))
 
-    def update_bt(self, adr):
-        icon_name = "bluetooth-active-symbolic" if adr != "off" else "bluetooth-disabled-symbolic"
+    def update_bt(self, name, powered):
+        icon_name = "bluetooth-active-symbolic" if powered else "bluetooth-disabled-symbolic"
         if icon_name != self.bt_icon_name:
             update_image(self.bt_image, icon_name, self.icon_size, self.icons_path)
             self.bt_icon_name = icon_name
 
-        self.bt_name = adr
+        self.bt_name = name
         if self.bt_label:
-            self.bt_label.set_text(adr)
+            self.bt_label.set_text(name)
 
     def update_brightness(self):
         value = get_brightness()

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -605,12 +605,21 @@ def create_pixbuf(icon_name, icon_size, icons_path=""):
             return pixbuf
 
 
-def bt_adr():
+def bt_info():
+    name, powered = "", False
     try:
-        adr = bluetooth.read_local_bdaddr()
-        return adr[0]
+        info = subprocess.check_output("btmgmt info", shell=True).decode("utf-8").strip().splitlines()
+        for line in info:
+            if "current settings" in line:
+                if "powered" in line:
+                    powered = True
+                continue
+            if "name" in line and "short" not in line:
+                name = line.split("name")[1].strip()
     except:
-        return "off"
+        pass
+
+    return name, powered
 
 
 def list_configs(config_dir):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.5.1',
+    version='0.5.2',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
The `python-pybluez` module crashes on python 3.10 (#72). Since the bug seems to have been first reported in February, and still remains unfixed, I decided to drop this dependency, and use the `btmgmt info` command from the `bluez-utils` package instead. Additional benefit is that we now have the BT name instead od MAC address.

TL/DR dependency changed: `bluez-utils` instead of `python-pybluez`.