### PR TITLE
support Adwaita theme

### DIFF
--- a/nwg_panel/modules/clock.py
+++ b/nwg_panel/modules/clock.py
@@ -83,10 +83,12 @@ class Clock(Gtk.EventBox):
         self.label.show()
 
     def on_enter_notify_event(self, widget, event):
-        self.get_style_context().set_state(Gtk.StateFlags.SELECTED)
+        widget.set_state_flags(Gtk.StateFlags.DROP_ACTIVE, clear=False)
+        widget.set_state_flags(Gtk.StateFlags.SELECTED, clear=False)
 
     def on_leave_notify_event(self, widget, event):
-        self.get_style_context().set_state(Gtk.StateFlags.NORMAL)
+        widget.unset_state_flags(Gtk.StateFlags.DROP_ACTIVE)
+        widget.unset_state_flags(Gtk.StateFlags.SELECTED)
 
     def on_button_press(self, widget, event):
         if event.button == 1 and self.settings["on-left-click"]:

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -243,7 +243,8 @@ class Controls(Gtk.EventBox):
                 if self.popup_window.menu_box:
                     self.popup_window.menu_box.hide()
         else:
-            self.get_style_context().set_state(Gtk.StateFlags.SELECTED)
+            widget.set_state_flags(Gtk.StateFlags.DROP_ACTIVE, clear=False)
+            widget.set_state_flags(Gtk.StateFlags.SELECTED, clear=False)
 
         # cancel popup window close, as it's probably unwanted ATM
         self.popup_window.on_window_enter()
@@ -251,7 +252,8 @@ class Controls(Gtk.EventBox):
         return True
 
     def on_leave_notify_event(self, widget, event):
-        self.get_style_context().set_state(Gtk.StateFlags.NORMAL)
+        widget.unset_state_flags(Gtk.StateFlags.DROP_ACTIVE)
+        widget.unset_state_flags(Gtk.StateFlags.SELECTED)
         return True
 
 
@@ -634,11 +636,13 @@ class PopupWindow(Gtk.Window):
         return True
 
     def on_enter_notify_event(self, widget, event):
-        widget.get_style_context().set_state(Gtk.StateFlags.SELECTED)
+        widget.set_state_flags(Gtk.StateFlags.DROP_ACTIVE, clear=False)
+        widget.set_state_flags(Gtk.StateFlags.SELECTED, clear=False)
         return True
 
     def on_leave_notify_event(self, widget, event):
-        widget.get_style_context().set_state(Gtk.StateFlags.NORMAL)
+        widget.unset_state_flags(Gtk.StateFlags.DROP_ACTIVE)
+        widget.unset_state_flags(Gtk.StateFlags.SELECTED)
         return True
 
     def set_bri(self, slider):
@@ -698,10 +702,12 @@ class SinkBox(Gtk.Box):
             self.show_all()
 
     def on_enter_notify_event(self, widget, event):
-        widget.get_style_context().set_state(Gtk.StateFlags.SELECTED)
+        widget.set_state_flags(Gtk.StateFlags.DROP_ACTIVE, clear=False)
+        widget.set_state_flags(Gtk.StateFlags.SELECTED, clear=False)
 
     def on_leave_notify_event(self, widget, event):
-        widget.get_style_context().set_state(Gtk.StateFlags.NORMAL)
+        widget.unset_state_flags(Gtk.StateFlags.DROP_ACTIVE)
+        widget.unset_state_flags(Gtk.StateFlags.SELECTED)
 
     def switch_sink(self, w, e, sink):
         if commands["pactl"]:

--- a/nwg_panel/modules/executor.py
+++ b/nwg_panel/modules/executor.py
@@ -143,10 +143,12 @@ class Executor(Gtk.EventBox):
             self.box.pack_start(self.image, False, False, 2)
 
     def on_enter_notify_event(self, widget, event):
-        self.get_style_context().set_state(Gtk.StateFlags.SELECTED)
+        widget.set_state_flags(Gtk.StateFlags.DROP_ACTIVE, clear=False)
+        widget.set_state_flags(Gtk.StateFlags.SELECTED, clear=False)
 
     def on_leave_notify_event(self, widget, event):
-        self.get_style_context().set_state(Gtk.StateFlags.NORMAL)
+        widget.unset_state_flags(Gtk.StateFlags.DROP_ACTIVE)
+        widget.unset_state_flags(Gtk.StateFlags.SELECTED)
 
     def on_button_press(self, widget, event):
         if event.button == 1 and self.settings["on-left-click"]:

--- a/nwg_panel/modules/sway_taskbar.py
+++ b/nwg_panel/modules/sway_taskbar.py
@@ -186,10 +186,12 @@ class WindowBox(Gtk.EventBox):
             self.box.pack_start(image, False, False, 4)
 
     def on_enter_notify_event(self, widget, event):
-        self.get_style_context().set_state(Gtk.StateFlags.SELECTED)
+        widget.set_state_flags(Gtk.StateFlags.DROP_ACTIVE, clear=False)
+        widget.set_state_flags(Gtk.StateFlags.SELECTED, clear=False)
 
     def on_leave_notify_event(self, widget, event):
-        self.get_style_context().set_state(Gtk.StateFlags.NORMAL)
+        widget.unset_state_flags(Gtk.StateFlags.DROP_ACTIVE)
+        widget.unset_state_flags(Gtk.StateFlags.SELECTED)
 
     def on_click(self, widget, event, at_widget):
         if event.button == 1:

--- a/nwg_panel/modules/sway_workspaces.py
+++ b/nwg_panel/modules/sway_workspaces.py
@@ -205,7 +205,9 @@ class SwayWorkspaces(Gtk.Box):
         nwg_panel.common.i3.command("workspace number {}".format(num))
 
     def on_enter_notify_event(self, widget, event):
-        widget.get_style_context().set_state(Gtk.StateFlags.SELECTED)
+        widget.set_state_flags(Gtk.StateFlags.DROP_ACTIVE, clear=False)
+        widget.set_state_flags(Gtk.StateFlags.SELECTED, clear=False)
 
     def on_leave_notify_event(self, widget, event):
-        widget.get_style_context().set_state(Gtk.StateFlags.NORMAL)
+        widget.unset_state_flags(Gtk.StateFlags.DROP_ACTIVE)
+        widget.unset_state_flags(Gtk.StateFlags.SELECTED)


### PR DESCRIPTION
Added setting `Gtk.StateFlags.DROP_ACTIVE` to hovered items, for it to be visible in Adwaita GTK theme and derivatives.