### PR TITLE
always executor if show if content found

### DIFF
--- a/nwg_panel/modules/executor.py
+++ b/nwg_panel/modules/executor.py
@@ -109,10 +109,11 @@ class Executor(Gtk.EventBox):
                             self.icon_path = new_path
                         except:
                             print("Failed setting image from {}".format(output[0].strip()))
-                        if not self.image.get_visible():
-                            self.image.show()
 
                 self.label.set_text(output[1].strip())
+                self.image.show()
+                if self.label.get_text():
+                    self.label.show()
         else:
             if self.image.get_visible():
                 self.image.hide()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.5.7',
+    version='0.5.8',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
this fixes the bug that made executors (icon + text) invisible if no content found on panel startup