### PR TITLE
add system tray module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.idea
 /venv
 /nwg-panel.egg-info/
+/nwg_panel.egg-info/
 /build/
 /dist/
+__pycache__

--- a/nwg_panel/common.py
+++ b/nwg_panel/common.py
@@ -13,6 +13,7 @@ taskbars_list = []
 scratchpads_list = []
 workspaces_list = []
 controls_list = []
+tray_list = []
 config_dir = ""
 dwl_data_file = None
 dwl_instances = []

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -453,7 +453,8 @@ class EditorWrapper(object):
                               "sway-taskbar",
                               "sway-workspaces",
                               "scratchpad",
-                              "dwl-tags"]
+                              "dwl-tags",
+        "tray"]
 
         self.scrolled_window = builder.get_object("scrolled-window")
 
@@ -500,6 +501,9 @@ class EditorWrapper(object):
         else:
             btn.set_sensitive(False)
             btn.set_tooltip_text("The 'swaync' package required")
+
+        btn = builder.get_object("btn-tray")
+        btn.connect("clicked", self.edit_tray)
 
         btn = builder.get_object("btn-executors")
         btn.connect("clicked", self.select_executor)
@@ -821,6 +825,8 @@ class EditorWrapper(object):
             self.update_executor()
         elif self.edited == "swaync":
             self.update_swaync()
+        elif self.edited == "tray":
+            self.update_tray()
         elif self.edited == "button":
             self.update_button()
         elif self.edited == "modules":
@@ -1148,6 +1154,56 @@ class EditorWrapper(object):
         settings["icon-size"] = int(self.nc_icon_size.get_value())
         settings["interval"] = int(self.nc_interval.get_value())
         settings["always-show-icon"] = self.nc_always_show_icon.get_active()
+
+        save_json(self.config, self.file)
+
+    def edit_tray(self, *args):
+        self.load_panel()
+        self.edited = "tray"
+        check_key(self.panel, "tray", {})
+        settings = self.panel["tray"]
+
+        defaults = {
+            "icon-size": 16,
+            "root-css-name": "tray",
+            "inner-css-name": "inner-tray",
+            "smooth-scrolling-threshold": 0
+        }
+        for key in defaults:
+            check_key(settings, key, defaults[key])
+
+        builder = Gtk.Builder.new_from_file(os.path.join(dir_name, "glade/config_tray.glade"))
+        grid = builder.get_object("grid")
+
+        self.nc_icon_size = builder.get_object("icon-size")
+        self.nc_icon_size.set_numeric(True)
+        adj = Gtk.Adjustment(value=0, lower=8, upper=128, step_increment=1, page_increment=10, page_size=1)
+        self.nc_icon_size.configure(adj, 1, 0)
+        self.nc_icon_size.set_value(settings["icon-size"])
+
+        self.nc_root_css_name = builder.get_object("root-css-name")
+        self.nc_root_css_name.set_text(settings["root-css-name"])
+
+        self.nc_inner_css_name = builder.get_object("inner-css-name")
+        self.nc_inner_css_name.set_text(settings["inner-css-name"])
+
+        self.nc_smooth_scrolling_threshold = builder.get_object("smooth-scrolling-threshold")
+        self.nc_smooth_scrolling_threshold.set_numeric(True)
+        adj = Gtk.Adjustment(value=0, lower=0, upper=3600, step_increment=1, page_increment=10, page_size=1)
+        self.nc_smooth_scrolling_threshold.configure(adj, 1, 0)
+        self.nc_smooth_scrolling_threshold.set_value(settings["smooth-scrolling-threshold"])
+
+        for item in self.scrolled_window.get_children():
+            item.destroy()
+        self.scrolled_window.add(grid)
+
+    def update_tray(self):
+        settings = self.panel["tray"]
+
+        settings["icon-size"] = int(self.nc_icon_size.get_value())
+        settings["root-css-name"] = self.nc_root_css_name.get_text()
+        settings["inner-css-name"] = self.nc_inner_css_name.get_text()
+        settings["smooth-scrolling-threshold"] = int(self.nc_smooth_scrolling_threshold.get_value())
 
         save_json(self.config, self.file)
 

--- a/nwg_panel/config/config
+++ b/nwg_panel/config/config
@@ -71,6 +71,10 @@
         ]
       }
     },
+    {
+      "root-css-name": "tray",
+      "inner-css-name": "inner-tray"
+    },
     "sway-taskbar": {
       "workspace-menu": [
         "1",

--- a/nwg_panel/config/config
+++ b/nwg_panel/config/config
@@ -71,7 +71,7 @@
         ]
       }
     },
-    {
+    "tray": {
       "root-css-name": "tray",
       "inner-css-name": "inner-tray"
     },

--- a/nwg_panel/glade/config_main.glade
+++ b/nwg_panel/glade/config_main.glade
@@ -101,6 +101,19 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkButton" id="btn-tray">
+                    <property name="label" translatable="yes">Tray</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">5</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkButton" id="btn-menu-start">
                     <property name="label" translatable="yes">Menu Start</property>
                     <property name="visible">True</property>

--- a/nwg_panel/glade/config_tray.glade
+++ b/nwg_panel/glade/config_tray.glade
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <!-- n-columns=3 n-rows=13 -->
+  <object class="GtkGrid" id="grid">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="row-spacing">6</property>
+    <property name="column-spacing">12</property>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Module :: Tray</property>
+        <attributes>
+          <attribute name="weight" value="bold"/>
+        </attributes>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">0</property>
+        <property name="width">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Icon size</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="icon-size">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Root CSS name</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="root-css-name">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Inner CSS name</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkEntry" id="inner-css-name">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">3</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes">Smooth Scrolling Threshold</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">4</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="smooth-scrolling-threshold">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">4</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -222,8 +222,8 @@ def instantiate_content(panel, container, content_list, icons_path=""):
 
         if item == "tray":
             tray_settings = {}
-            if "tray-settings" in panel:
-                tray_settings = panel["tray-settings"]
+            if "tray" in panel:
+                tray_settings = panel["tray"]
             tray = sni_system_tray.Tray(tray_settings, icons_path)
             common.tray_list.append(tray)
             container.pack_start(tray, False, False, panel["items-padding"])

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -50,6 +50,7 @@ from nwg_panel.modules.menu_start import MenuStart
 dir_name = os.path.dirname(__file__)
 
 from nwg_panel import common
+from nwg_panel.modules import sni_system_tray
 
 sway = os.getenv('SWAYSOCK') is not None
 if sway:
@@ -72,6 +73,7 @@ def signal_handler(sig, frame):
     desc = {2: "SIGINT", 15: "SIGTERM", 10: "SIGUSR1"}
     if sig == 2 or sig == 15:
         print("Terminated with {}".format(desc[sig]))
+        sni_system_tray.deinit_tray()
         Gtk.main_quit()
     elif sig == sig_dwl:
         refresh_dwl()
@@ -217,6 +219,14 @@ def instantiate_content(panel, container, content_list, icons_path=""):
                     dwl_tags.refresh(dwl_data)
             else:
                 print("{} data file not found".format(common.dwl_data_file))
+
+        if item == "tray":
+            tray_settings = {}
+            if "tray-settings" in panel:
+                tray_settings = panel["tray-settings"]
+            tray = sni_system_tray.Tray(tray_settings, icons_path)
+            common.tray_list.append(tray)
+            container.pack_start(tray, False, False, panel["items-padding"])
 
 
 def main():
@@ -539,6 +549,9 @@ def main():
         common.outputs = list_outputs(sway=sway, tree=tree, silent=True)
         common.outputs_num = len(common.outputs)
     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 200, check_tree)
+
+    if len(common.tray_list) > 0:
+        sni_system_tray.init_tray(common.tray_list)
 
     Gtk.main()
 

--- a/nwg_panel/modules/sni_system_tray/__init__.py
+++ b/nwg_panel/modules/sni_system_tray/__init__.py
@@ -1,0 +1,20 @@
+import typing
+from threading import Thread
+
+from . import host, watcher
+from .tray import Tray
+
+
+def init_tray(trays: typing.List[Tray]):
+    host_thread = Thread(target=host.init, args=[0, trays])
+    host_thread.daemon = True
+    host_thread.start()
+
+    watcher_thread = Thread(target=watcher.init)
+    watcher_thread.daemon = True
+    watcher_thread.start()
+
+
+def deinit_tray():
+    host.deinit()
+    watcher.deinit()

--- a/nwg_panel/modules/sni_system_tray/host.py
+++ b/nwg_panel/modules/sni_system_tray/host.py
@@ -1,0 +1,128 @@
+import typing
+import os
+
+from dasbus.connection import SessionMessageBus
+from dasbus.loop import EventLoop
+from dasbus.client.observer import DBusObserver
+from dasbus.client.proxy import disconnect_proxy
+
+from .watcher import WATCHER_SERVICE_NAME, WATCHER_OBJECT_PATH
+from .tray import Tray
+from .item import StatusNotifierItem
+
+HOST_SERVICE_NAME_TEMPLATE = "org.kde.StatusNotifierHost-{}-{}"
+HOST_OBJECT_PATH_TEMPLATE = "/StatusNotifierHost/{}"
+
+dasbus_event_loop: typing.Union[EventLoop, None] = None
+
+
+def get_service_name_and_object_path(service: str) -> (str, str):
+    index = service.find("/")
+    if index != len(service):
+        return service[0:index], service[index:]
+    return service, "/StatusNotifierItem"
+
+
+class StatusNotifierHostInterface(object):
+    def __init__(self, host_id, trays: typing.List[Tray]):
+        self.host_id = host_id
+        self.trays = trays
+
+        self._statusNotifierItems = []
+        self.watcher_proxy = None
+        self.session_bus = SessionMessageBus()
+
+        self.host_service_name = HOST_SERVICE_NAME_TEMPLATE.format(os.getpid(), self.host_id)
+        self.host_object_path = HOST_OBJECT_PATH_TEMPLATE.format(self.host_id)
+        self.session_bus.register_service(self.host_service_name)
+
+        self.watcher_service_observer = DBusObserver(
+            message_bus=self.session_bus,
+            service_name=WATCHER_SERVICE_NAME
+        )
+        self.watcher_service_observer.service_available.connect(
+            self.watcher_available_handler
+        )
+        self.watcher_service_observer.service_unavailable.connect(
+            self.watcher_unavailable_handler
+        )
+        self.watcher_service_observer.connect_once_available()
+
+    def __del__(self):
+        if self.watcher_proxy is not None:
+            disconnect_proxy(self.watcher_proxy)
+        self.watcher_service_observer.disconnect()
+        self.session_bus.disconnect()
+
+    def watcher_available_handler(self, _observer):
+        print("StatusNotifierHostInterface -> watcher_available_handler")
+        self.watcher_proxy = self.session_bus.get_proxy(WATCHER_SERVICE_NAME, WATCHER_OBJECT_PATH)
+        self.watcher_proxy.StatusNotifierItemRegistered.connect(self.item_registered_handler)
+        self.watcher_proxy.StatusNotifierItemUnregistered.connect(self.item_unregistered_handler)
+        self.watcher_proxy.RegisterStatusNotifierHost(self.host_object_path, callback=lambda _: None)
+
+    def watcher_unavailable_handler(self, _observer):
+        print("StatusNotifierHostInterface -> watcher_unavailable_handler")
+        self._statusNotifierItems.clear()
+        disconnect_proxy(self.watcher_proxy)
+        self.watcher_proxy = None
+
+    def item_registered_handler(self, full_service_service):
+        print(
+            "StatusNotifierHostInterface -> item_registered_handler\n  full_service_name: {}".format(
+                full_service_service
+            )
+        )
+        service_name, object_path = get_service_name_and_object_path(full_service_service)
+        if self.find_item(service_name, object_path) is None:
+            item = StatusNotifierItem(service_name, object_path)
+            item.set_on_loaded_callback(self.item_loaded_handler)
+            item.set_on_updated_callback(self.item_updated_handler)
+            self._statusNotifierItems.append(item)
+
+    def item_unregistered_handler(self, full_service_service):
+        print(
+            "StatusNotifierHostInterface -> item_unregistered_handler\n  full_service_name: {}".format(
+                full_service_service
+            )
+        )
+        service_name, object_path = get_service_name_and_object_path(full_service_service)
+        item = self.find_item(service_name, object_path)
+        if item is not None:
+            self._statusNotifierItems.remove(item)
+            for tray in self.trays:
+                tray.remove_item(item)
+
+    def find_item(self, service_name, object_path) -> typing.Union[StatusNotifierItem, None]:
+        for item in self._statusNotifierItems:
+            if item.service_name == service_name and item.object_path == object_path:
+                return item
+        else:
+            return None
+
+    def item_loaded_handler(self, item):
+        for tray in self.trays:
+            tray.add_item(item)
+
+    def item_updated_handler(self, item, changed_properties):
+        for tray in self.trays:
+            tray.update_item(item, changed_properties)
+
+
+def init(host_id, trays: typing.List[Tray]):
+    _status_notifier_host_interface = StatusNotifierHostInterface(host_id, trays)
+
+    global dasbus_event_loop
+    if dasbus_event_loop is None:
+        print("host.init(): running dasbus.EventLoop")
+        dasbus_event_loop = EventLoop()
+        dasbus_event_loop.run()
+
+
+def deinit():
+    global dasbus_event_loop
+    if dasbus_event_loop is not None:
+        print("host.deinit(): quitting dasbus.EventLoop")
+        dasbus_event_loop.quit()
+    if dasbus_event_loop is not None:
+        dasbus_event_loop = None

--- a/nwg_panel/modules/sni_system_tray/item.py
+++ b/nwg_panel/modules/sni_system_tray/item.py
@@ -129,3 +129,6 @@ class StatusNotifierItem(object):
 
     def secondary_action(self, event: Gdk.EventButton):
         self.item_proxy.SecondaryAction(event.x, event.y)
+
+    def scroll(self, distance, direction):
+        self.item_proxy.Scroll(distance, direction)

--- a/nwg_panel/modules/sni_system_tray/item.py
+++ b/nwg_panel/modules/sni_system_tray/item.py
@@ -1,0 +1,96 @@
+from dasbus.connection import SessionMessageBus
+from dasbus.client.observer import DBusObserver
+from dasbus.client.proxy import disconnect_proxy
+
+PROPERTIES = [
+    "Id",
+    "Category",
+    "Title",
+    "Status",
+    "WindowId",
+    "IconName",
+    "IconPixmap",
+    "OverlayIconName",
+    "OverlayIconPixmap",
+    "AttentionIconName",
+    "AttentionIconPixmap",
+    "AttentionMovieName",
+    "ToolTip",
+    "IconThemePath",
+    "ItemIsMenu",
+    "Menu"
+]
+
+
+class StatusNotifierItem(object):
+    def __init__(self, service_name, object_path):
+        self.service_name = service_name
+        self.object_path = object_path
+        self.on_loaded_callback = None
+        self.on_updated_callback = None
+        self.session_bus = SessionMessageBus()
+        self.properties = {
+            "ItemIsMenu": True
+        }
+        self.item_proxy = None
+
+        self.item_observer = DBusObserver(
+            message_bus=self.session_bus,
+            service_name=self.service_name
+        )
+        self.item_observer.service_available.connect(
+            self.item_available_handler
+        )
+        self.item_observer.service_unavailable.connect(
+            self.item_unavailable_handler
+        )
+        self.item_observer.connect_once_available()
+
+    def __del__(self):
+        if self.item_proxy is not None:
+            disconnect_proxy(self.item_proxy)
+        self.item_observer.disconnect()
+        self.session_bus.disconnect()
+
+    def item_available_handler(self, _observer):
+        self.item_proxy = self.session_bus.get_proxy(self.service_name, self.object_path)
+        self.item_proxy.PropertiesChanged.connect(
+            lambda _if, changed_properties, _invalid: self.change_handler(list(changed_properties))
+        )
+        self.item_proxy.NewTitle.connect(
+            lambda _title: self.change_handler(["Title"])
+        )
+        self.item_proxy.NewIcon.connect(
+            lambda _icon_name, _icon_pixmap: self.change_handler(["IconName", "IconPixmap"])
+        )
+        self.item_proxy.NewAttentionIcon.connect(
+            lambda _icon_name, _icon_pixmap: self.change_handler(["AttentionIconName", "AttentionIconPixmap"])
+        )
+        self.item_proxy.NewIconThemePath.connect(
+            lambda _icon_theme_path: self.change_handler(["IconThemePath"])
+        )
+        self.item_proxy.NewStatus.connect(
+            lambda _status: self.change_handler(["Status"])
+        )
+        for name in PROPERTIES:
+            if hasattr(self.item_proxy, name):
+                self.properties[name] = getattr(self.item_proxy, name)
+        if self.on_loaded_callback is not None:
+            self.on_loaded_callback(self)
+
+    def item_unavailable_handler(self, _observer):
+        disconnect_proxy(self.item_proxy)
+        self.item_proxy = None
+
+    def change_handler(self, changed_properties: list[str]):
+        if len(changed_properties) > 0:
+            for name, value in changed_properties:
+                self.properties[name] = value
+            if self.on_updated_callback is not None:
+                self.on_updated_callback(self, changed_properties)
+
+    def set_on_loaded_callback(self, callback):
+        self.on_loaded_callback = callback
+
+    def set_on_updated_callback(self, callback):
+        self.on_updated_callback = callback

--- a/nwg_panel/modules/sni_system_tray/menu.py
+++ b/nwg_panel/modules/sni_system_tray/menu.py
@@ -1,0 +1,62 @@
+import typing
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("DbusmenuGtk3", "0.4")
+
+from gi.repository import Gdk, Gtk, DbusmenuGtk3
+
+from dasbus.connection import SessionMessageBus
+from dasbus.client.observer import DBusObserver
+
+
+class Menu(object):
+    def __init__(self, service_name, object_path, parent_widget: Gtk.Widget):
+        self.service_name = service_name
+        self.object_path = object_path
+        self.parent_widget = parent_widget
+        self.session_bus = SessionMessageBus()
+        self.menu_widget: typing.Union[None, DbusmenuGtk3.Menu] = None
+
+        self.menu_observer = DBusObserver(
+            message_bus=self.session_bus,
+            service_name=self.service_name
+        )
+        self.menu_observer.service_available.connect(
+            self.menu_available_handler
+        )
+        self.menu_observer.service_unavailable.connect(
+            self.menu_unavailable_handler
+        )
+        self.menu_observer.connect_once_available()
+
+    def __del__(self):
+        self.menu_observer.disconnect()
+        self.session_bus.disconnect()
+
+    def menu_available_handler(self, _observer):
+        print(
+            "Menu -> menu_available_handler: Connecting to menu over dbus:\n"
+            "  service_name: {}\n"
+            "  object_path: {}".format(
+                self.service_name,
+                self.object_path
+            )
+        )
+        self.menu_widget = DbusmenuGtk3.Menu().new(
+            dbus_name=self.service_name,
+            dbus_object=self.object_path
+        )
+        self.menu_widget.show()
+        self.parent_widget.connect("button-press-event", self.button_press_event_handler)
+
+    def menu_unavailable_handler(self, _observer):
+        self.parent_widget.disconnect_by_func(self.button_press_event_handler)
+
+    def button_press_event_handler(self, _w, event):
+        self.menu_widget.popup_at_widget(
+            self.parent_widget,
+            Gdk.Gravity.SOUTH,
+            Gdk.Gravity.NORTH,
+            event
+        )

--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -10,31 +10,37 @@ from nwg_panel.tools import check_key, get_config_dir
 from .item import StatusNotifierItem
 
 
-def load_icon(image, icon_name, icon_size, icons_path=""):
+def load_icon(image, icon_name: str, icon_size, icons_path=""):
     icon_theme = Gtk.IconTheme.get_default()
     search_path = icon_theme.get_search_path()
-    if icons_path:
-        search_path.append(icons_path)
-        icon_theme.set_search_path(search_path)
-    if icon_theme.has_icon(icon_name):
-        pixbuf = icon_theme.load_icon(icon_name, icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
-    elif icon_theme.has_icon(icon_name.lower()):
-        pixbuf = icon_theme.load_icon(icon_name.lower(), icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
-    else:
-        try:
+    try:
+        if icons_path:
+            search_path.append(icons_path)
+            icon_theme.set_search_path(search_path)
+
+        if icon_theme.has_icon(icon_name):
             pixbuf = icon_theme.load_icon(icon_name, icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
-        except GLib.GError:
-            print(
-                "tray.update_icon -> icon not found\n  icon_name: {}\n  search_path: {}".format(
-                    icon_name,
-                    search_path
-                ),
-                file=sys.stderr
-            )
-            path = os.path.join(get_config_dir(), "icons_light/icon-missing.svg")
-            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, icon_size, icon_size)
+        elif icon_theme.has_icon(icon_name.lower()):
+            pixbuf = icon_theme.load_icon(icon_name.lower(), icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
+        elif icon_name.startswith("/"):
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(icon_name, icon_size, icon_size)
+        else:
+            pixbuf = icon_theme.load_icon(icon_name, icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
+
+    except GLib.GError:
+        print(
+            "tray.update_icon -> icon not found\n  icon_name: {}\n  search_path: {}".format(
+                icon_name,
+                search_path
+            ),
+            file=sys.stderr
+        )
+        path = os.path.join(get_config_dir(), "icons_light/icon-missing.svg")
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, icon_size, icon_size)
+
     # TODO: if image height is different to icon_size, resize to match, while maintaining
     #  aspect ratio. Width can be ignored.
+
     image.set_from_pixbuf(pixbuf)
 
 

--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -1,0 +1,135 @@
+import os
+import sys
+import gi
+
+gi.require_version('Gtk', '3.0')
+
+from gi.repository import Gtk, GLib, GdkPixbuf
+
+from nwg_panel.tools import check_key, get_config_dir
+from .item import StatusNotifierItem
+
+
+def load_icon(image, icon_name, icon_size, icons_path=""):
+    icon_theme = Gtk.IconTheme.get_default()
+    search_path = icon_theme.get_search_path()
+    if icons_path:
+        search_path.append(icons_path)
+        icon_theme.set_search_path(search_path)
+    if icon_theme.has_icon(icon_name):
+        pixbuf = icon_theme.load_icon(icon_name, icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
+    elif icon_theme.has_icon(icon_name.lower()):
+        pixbuf = icon_theme.load_icon(icon_name.lower(), icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
+    else:
+        try:
+            pixbuf = icon_theme.load_icon(icon_name, icon_size, Gtk.IconLookupFlags.FORCE_SIZE)
+        except GLib.GError:
+            print(
+                "tray.update_icon -> icon not found\n  icon_name: {}\n  search_path: {}".format(
+                    icon_name,
+                    search_path
+                ),
+                file=sys.stderr
+            )
+            path = os.path.join(get_config_dir(), "icons_light/icon-missing.svg")
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(path, icon_size, icon_size)
+    # TODO: if image height is different to icon_size, resize to match, while maintaining
+    #  aspect ratio. Width can be ignored.
+    image.set_from_pixbuf(pixbuf)
+
+
+def update_icon(image, item, icon_size, icon_path):
+    if "IconThemePath" in item.properties:
+        icon_path = item.properties["IconThemePath"]
+    load_icon(image, item.properties["IconName"], icon_size, icon_path)
+
+
+def update_status(event_box, item):
+    if "Status" in item.properties:
+        status = item.properties["Status"].lower()
+        event_box.set_visible(status != "passive")
+        event_box_style = event_box.get_style_context()
+        for class_name in event_box_style.list_classes():
+            event_box_style.remove_class(class_name)
+        if status == "needsattention":
+            event_box_style.add_class("needs-attention")
+        event_box_style.add_class(status)
+
+
+class Tray(Gtk.EventBox):
+    def __init__(self, settings, icons_path=""):
+        self.settings = settings
+        self.icons_path = icons_path
+        Gtk.EventBox.__init__(self)
+
+        check_key(settings, "icon-size", 16)
+        check_key(settings, "root-css-name", "tray")
+
+        self.set_property("name", settings["root-css-name"])
+
+        self.icon_size = settings["icon-size"]
+
+        self.box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        self.add(self.box)
+
+        self.items = {}
+
+    def add_item(self, item: StatusNotifierItem):
+        print("Tray -> add_item: {}".format(item.properties))
+        full_service_name = "{}{}".format(item.service_name, item.object_path)
+        if full_service_name not in self.items:
+            event_box = Gtk.EventBox()
+            image = Gtk.Image()
+
+            if "IconPixmap" in item.properties:
+                # TODO: handle loading pixbuf from dbus
+                pass
+            else:
+                update_icon(image, item, self.icon_size, self.icons_path)
+
+            if "Tooltip" in item.properties:
+                # TODO: handle tooltip variant type
+                pass
+
+            if "Title" in item.properties:
+                image.set_tooltip_markup(item.properties["Title"])
+
+            update_status(event_box, item)
+
+            event_box.add(image)
+            self.box.pack_start(event_box, False, False, 6)
+            self.box.show_all()
+
+            self.items[full_service_name] = {
+                "event_box": event_box,
+                "image": image,
+                "item": item
+            }
+
+    def update_item(self, item: StatusNotifierItem, changed_properties: list[str]):
+        full_service_name = "{}{}".format(item.service_name, item.object_path)
+        event_box = self.items[full_service_name]["event_box"]
+        image = self.items[full_service_name]["image"]
+
+        if "IconPixmap" in changed_properties:
+            # TODO: handle loading pixbuf from dbus
+            pass
+        elif "IconThemePath" in changed_properties or "IconName" in changed_properties:
+            update_icon(image, item, self.icon_size, self.icons_path)
+
+        if "Tooltip" in changed_properties:
+            # handle tooltip variant type
+            pass
+
+        if "Title" in changed_properties:
+            image.set_tooltip_markup(item.properties["Title"])
+
+        update_status(event_box, item)
+
+        event_box.show_all()
+
+    def remove_item(self, item: StatusNotifierItem):
+        full_service_name = "{}{}".format(item.service_name, item.object_path)
+        self.box.remove(self.items[full_service_name]["event_box"])
+        self.items.pop(full_service_name)
+        self.box.show_all()

--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -143,7 +143,8 @@ class Tray(Gtk.EventBox):
                 self.menu = Menu(
                     service_name=item.service_name,
                     object_path=item.properties["Menu"],
-                    parent_widget=event_box
+                    event_box=event_box,
+                    item=item
                 )
 
             self.items[full_service_name] = {

--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -106,12 +106,15 @@ class Tray(Gtk.EventBox):
 
         check_key(settings, "icon-size", 16)
         check_key(settings, "root-css-name", "tray")
+        check_key(settings, "inner-css-name", "inner-tray")
+        check_key(settings, "smooth-scrolling-threshold", 0)
 
         self.set_property("name", settings["root-css-name"])
 
         self.icon_size = settings["icon-size"]
 
         self.box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        self.box.set_property("name", settings["inner-css-name"])
         self.add(self.box)
 
         self.items = {}
@@ -143,6 +146,7 @@ class Tray(Gtk.EventBox):
                 self.menu = Menu(
                     service_name=item.service_name,
                     object_path=item.properties["Menu"],
+                    settings=self.settings,
                     event_box=event_box,
                     item=item
                 )

--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -2,12 +2,13 @@ import os
 import sys
 import gi
 
-gi.require_version('Gtk', '3.0')
+gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk, GLib, GdkPixbuf
 
 from nwg_panel.tools import check_key, get_config_dir
 from .item import StatusNotifierItem
+from .menu import Menu
 
 
 def load_icon(image, icon_name: str, icon_size, icons_path=""):
@@ -29,7 +30,7 @@ def load_icon(image, icon_name: str, icon_size, icons_path=""):
 
     except GLib.GError:
         print(
-            "tray.update_icon -> icon not found\n  icon_name: {}\n  search_path: {}".format(
+            "tray -> update_icon: icon not found\n  icon_name: {}\n  search_path: {}".format(
                 icon_name,
                 search_path
             ),
@@ -64,6 +65,7 @@ def update_status(event_box, item):
 
 class Tray(Gtk.EventBox):
     def __init__(self, settings, icons_path=""):
+        self.menu = None
         self.settings = settings
         self.icons_path = icons_path
         Gtk.EventBox.__init__(self)
@@ -105,6 +107,13 @@ class Tray(Gtk.EventBox):
             event_box.add(image)
             self.box.pack_start(event_box, False, False, 6)
             self.box.show_all()
+
+            if "Menu" in item.properties:
+                self.menu = Menu(
+                    service_name=item.service_name,
+                    object_path=item.properties["Menu"],
+                    parent_widget=event_box
+                )
 
             self.items[full_service_name] = {
                 "event_box": event_box,

--- a/nwg_panel/modules/sni_system_tray/watcher.py
+++ b/nwg_panel/modules/sni_system_tray/watcher.py
@@ -1,0 +1,230 @@
+import typing
+
+from dasbus.connection import SessionMessageBus
+from dasbus.loop import EventLoop
+from dasbus.signal import Signal
+from dasbus.client.observer import DBusObserver
+from dasbus.server.interface import accepts_additional_arguments
+import dasbus.typing
+
+WATCHER_SERVICE_NAME = "org.kde.StatusNotifierWatcher"
+WATCHER_OBJECT_PATH = "/StatusNotifierWatcher"
+
+dasbus_event_loop: typing.Union[EventLoop, None] = None
+
+
+class StatusNotifierWatcherInterface(object):
+    __dbus_xml__ = """
+        <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+        <node>
+            <interface name="org.kde.StatusNotifierWatcher">
+                <annotation name="org.gtk.GDBus.C.Name" value="Watcher" />
+
+                <method name="RegisterStatusNotifierItem">
+                    <annotation name="org.gtk.GDBus.C.Name" value="RegisterItem" />
+                    <arg name="service" type="s" direction="in"/>
+                </method>
+
+                <method name="RegisterStatusNotifierHost">
+                    <annotation name="org.gtk.GDBus.C.Name" value="RegisterHost" />
+                    <arg name="service" type="s" direction="in"/>
+                </method>
+
+                <property name="RegisteredStatusNotifierItems" type="as" access="read">
+                    <annotation name="org.gtk.GDBus.C.Name" value="RegisteredItems" />
+                    <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QStringList"/>
+                </property>
+
+                <property name="IsStatusNotifierHostRegistered" type="b" access="read">
+                    <annotation name="org.gtk.GDBus.C.Name" value="IsHostRegistered" />
+                </property>
+
+                <property name="ProtocolVersion" type="i" access="read"/>
+
+                <signal name="StatusNotifierItemRegistered">
+                    <annotation name="org.gtk.GDBus.C.Name" value="ItemRegistered" />
+                    <arg type="s" direction="out" name="service" />
+                </signal>
+
+                <signal name="StatusNotifierItemUnregistered">
+                    <annotation name="org.gtk.GDBus.C.Name" value="ItemUnregistered" />
+                    <arg type="s" direction="out" name="service" />
+                </signal>
+
+                <signal name="StatusNotifierHostRegistered">
+                    <annotation name="org.gtk.GDBus.C.Name" value="HostRegistered" />
+                </signal>
+
+                <signal name="StatusNotifierHostUnregistered">
+                    <annotation name="org.gtk.GDBus.C.Name" value="HostUnregistered" />
+                </signal>
+
+            </interface>
+        </node>
+    """
+
+    PropertiesChanged = Signal()
+    StatusNotifierItemRegistered = Signal()
+    StatusNotifierItemUnregistered = Signal()
+    StatusNotifierHostRegistered = Signal()
+    StatusNotifierHostUnregistered = Signal()
+
+    def __init__(self):
+        self._statusNotifierItems = []
+        self._statusNotifierHosts = []
+        self._isStatusNotifierHostRegistered = False
+        self._protocolVersion = 0
+        self.session_bus = SessionMessageBus()
+
+    def __del__(self):
+        self.session_bus.disconnect()
+
+    @accepts_additional_arguments
+    def RegisterStatusNotifierItem(self, service, call_info):
+        print(
+            "StatusNotifierWatcher -> RegisterStatusNotifierItem\n  service: {}\n  sender: {}".format(
+                service,
+                call_info["sender"]
+            )
+        )
+
+        # libappindicator sends object path, use sender name and object path
+        if service[0] == "/":
+            full_service_name = "{}{}".format(call_info["sender"], service)
+
+        # xembedsniproxy sends item name, use the item from the argument
+        elif service[0] == ":":
+            full_service_name = "{}{}".format(service, "/StatusNotifierItem")
+
+        else:
+            full_service_name = "{}{}".format(call_info["sender"], "/StatusNotifierItem")
+
+        if full_service_name not in self._statusNotifierItems:
+            item_service_observer = DBusObserver(
+                message_bus=self.session_bus,
+                service_name=call_info["sender"]
+            )
+            item_service_observer.service_available.connect(
+                lambda _observer: self.item_available_handler(full_service_name)
+            )
+            item_service_observer.service_unavailable.connect(
+                lambda _observer: self.item_unavailable_handler(full_service_name)
+            )
+            item_service_observer.connect_once_available()
+        else:
+            print(
+                (
+                    "StatusNotifierWatcher -> RegisterStatusNotifierItem: item already registered\n"
+                    "  full_service_name: {}"
+                ).format(full_service_name, service)
+            )
+
+    @accepts_additional_arguments
+    def RegisterStatusNotifierHost(self, service, call_info):
+        print("StatusNotifierWatcher -> RegisterStatusNotifierHost: {}".format(service))
+        if call_info["sender"] not in self._statusNotifierHosts:
+            host_service_observer = DBusObserver(
+                message_bus=self.session_bus,
+                service_name=call_info["sender"]
+            )
+            host_service_observer.service_available.connect(
+                self.host_available_handler
+            )
+            host_service_observer.service_unavailable.connect(
+                self.host_unavailable_handler
+            )
+            host_service_observer.connect_once_available()
+        else:
+            print(
+                "StatusNotifierWatcher -> RegisterStatusNotifierHost: host already registered\n  service: {}\n  sender: {})".format(
+                    service,
+                    call_info["sender"]
+                )
+            )
+
+    @property
+    def RegisteredStatusNotifierItems(self) -> list:
+        print("StatusNotifierWatcher -> RegisteredStatusNotifierItems")
+        return self._statusNotifierItems
+
+    @property
+    def IsStatusNotifierHostRegistered(self) -> bool:
+        print(
+            "StatusNotifierWatcher -> IsStatusNotifierHostRegistered: {}".format(
+                str(len(self._statusNotifierHosts) > 0)
+            )
+        )
+        return len(self._statusNotifierHosts) > 0
+
+    @property
+    def ProtocolVersion(self) -> int:
+        print("StatusNotifierWatcher -> ProtocolVersion: ".format(str(self._protocolVersion)))
+        return self._protocolVersion
+
+    def item_available_handler(self, full_service_name):
+        print(
+            "StatusNotifierWatcher -> item_available_handler\n  full_service_name: {}".format(
+                full_service_name
+            )
+        )
+        self._statusNotifierItems.append(full_service_name)
+        self.StatusNotifierItemRegistered.emit(full_service_name)
+        self.PropertiesChanged.emit(WATCHER_SERVICE_NAME, {
+            "RegisteredStatusNotifierItems": dasbus.typing.get_variant(
+                dasbus.typing.List[dasbus.typing.Str],
+                self._statusNotifierItems
+            )
+        }, [])
+
+    def item_unavailable_handler(self, full_service_name):
+        print(
+            "StatusNotifierWatcher -> item_unavailable_handler\n  full_service_name: {}".format(
+                full_service_name
+            )
+        )
+        if full_service_name in set(self._statusNotifierItems):
+            self._statusNotifierItems.remove(full_service_name)
+            self.StatusNotifierItemUnregistered.emit(full_service_name)
+            self.PropertiesChanged.emit(WATCHER_SERVICE_NAME, {
+                "RegisteredStatusNotifierItems": dasbus.typing.get_variant(
+                    dasbus.typing.List[dasbus.typing.Str],
+                    self._statusNotifierItems
+                )
+            }, [])
+
+    def host_available_handler(self, observer):
+        self._statusNotifierHosts.append(observer.service_name)
+        self.StatusNotifierHostRegistered.emit()
+        self.PropertiesChanged.emit(WATCHER_SERVICE_NAME, {
+            "IsStatusNotifierHostRegistered": dasbus.typing.get_variant(dasbus.typing.Bool, True)
+        }, [])
+
+    def host_unavailable_handler(self, observer):
+        self._statusNotifierHosts.remove(observer.service_name)
+        self.StatusNotifierHostUnregistered.emit()
+        if len(self._statusNotifierHosts) == 0:
+            self.PropertiesChanged.emit(WATCHER_SERVICE_NAME, {
+                "IsStatusNotifierHostRegistered": dasbus.typing.get_variant(dasbus.typing.Bool, False)
+            }, [])
+
+
+def init():
+    session_bus = SessionMessageBus()
+    session_bus.publish_object(WATCHER_OBJECT_PATH, StatusNotifierWatcherInterface())
+    session_bus.register_service(WATCHER_SERVICE_NAME)
+    print("watcher.init(): published {}{} on dbus.".format(WATCHER_SERVICE_NAME, WATCHER_OBJECT_PATH))
+
+    global dasbus_event_loop
+    if dasbus_event_loop is None:
+        print("watcher.init(): running dasbus.EventLoop")
+        dasbus_event_loop = EventLoop()
+        dasbus_event_loop.run()
+
+
+def deinit():
+    global dasbus_event_loop
+    if dasbus_event_loop is not None:
+        print("watcher.deinit(): quitting dasbus.EventLoop")
+        dasbus_event_loop.quit()
+    if dasbus_event_loop is not None:
+        dasbus_event_loop = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+PyGObject~=3.42.0
+psutil~=5.9.0
+i3ipc~=2.2.1
+setuptools~=57.0.0
+dasbus~=1.6


### PR DESCRIPTION
This is an attempt to create an `SNI` based system tray module for `nwg-panel`.

Progress:
- [X] dbus watcher
- [X] dbus host
- [X] item
- [X] tray module (showing real app icons)
- [X] wire in `DbusmenuGtk3`
- [x] cleanup and action any feedback

I think the menu's can be implemented by leveraging the [libdbusmenu](https://github.com/AyatanaIndicators/libdbusmenu) library. There is example python code in the following two tests:
- https://github.com/AyatanaIndicators/libdbusmenu/blob/master/tests/test-glib-simple-items.py
- https://github.com/AyatanaIndicators/libdbusmenu/blob/master/tests/test-gtk-shortcut-client.py

I'm a front-end developer by day so I apologise in advance for butchering the python language :wink: All feedback welcome!

This addresses #41