### PR TITLE
remove swaync from known modules

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -453,8 +453,7 @@ class EditorWrapper(object):
                               "sway-taskbar",
                               "sway-workspaces",
                               "scratchpad",
-                              "dwl-tags",
-                              "swaync"]
+                              "dwl-tags"]
 
         self.scrolled_window = builder.get_object("scrolled-window")
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.6.0',
+    version='0.6.1',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
As swaync has always the fixed position, next to the Controls module, it should not be visible on the modules list.