### PR TITLE
Fix unintended control changes

### DIFF
--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -632,6 +632,7 @@ class PopupWindow(Gtk.Window):
                     update_image(self.vol_image, self.parent.vol_icon_name, self.icon_size, self.icons_path)
                     self.vol_icon_name = self.parent.vol_icon_name
 
+                self.vol_scale.set_draw_value(False if self.parent.vol_value > 100 else True) # Dont display val out of scale
                 with self.vol_scale.handler_block(self.vol_scale_handler):
                     self.vol_scale.set_value(self.parent.vol_value)
 

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -192,26 +192,31 @@ class Controls(Gtk.EventBox):
 
     def update_brightness(self):
         value = get_brightness(device=self.settings["backlight-device"])
-        icon_name = bri_icon_name(value)
+        if self.bri_value != value:
+            icon_name = bri_icon_name(value)
 
-        if icon_name != self.bri_icon_name:
-            update_image(self.bri_image, icon_name, self.icon_size, self.icons_path)
-            self.bri_icon_name = icon_name
+            if icon_name != self.bri_icon_name:
+                update_image(self.bri_image, icon_name, self.icon_size, self.icons_path)
+                self.bri_icon_name = icon_name
 
-        self.bri_value = value
-        if self.bri_label:
-            self.bri_label.set_text("{}%".format(value))
+            if self.bri_label:
+                self.bri_label.set_text("{}%".format(value))
+
+            self.bri_value = value
 
     def update_volume(self):
-        self.vol_value, self.vol_muted = get_volume()
-        icon_name = vol_icon_name(self.vol_value, self.vol_muted)
+        volume = get_volume()
+        if (self.vol_value, self.vol_muted != volume):
+            icon_name = vol_icon_name(*volume)
+            
+            if icon_name != self.vol_icon_name:
+                update_image(self.vol_image, icon_name, self.settings["icon-size"], self.icons_path)
+                self.vol_icon_name = icon_name
 
-        if icon_name != self.vol_icon_name:
-            update_image(self.vol_image, icon_name, self.settings["icon-size"], self.icons_path)
-            self.vol_icon_name = icon_name
+            if self.vol_label:
+                self.vol_label.set_text("{}%".format(volume[0]))
 
-        if self.vol_label:
-            self.vol_label.set_text("{}%".format(self.vol_value))
+            self.vol_value, self.vol_muted = volume
 
     def update_battery(self, value, charging):
         icon_name = bat_icon_name(value, charging)

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -287,7 +287,9 @@ class PopupWindow(Gtk.Window):
         self.sink_box = None
 
         self.bri_scale = None
+        self.bri_scale_handler = None
         self.vol_scale = None
+        self.vol_scale_handler = None
         
         self.src_tag = 0
         
@@ -343,7 +345,7 @@ class PopupWindow(Gtk.Window):
             inner_hbox.pack_start(self.bri_image, False, False, 6)
 
             self.bri_scale = Gtk.Scale.new_with_range(orientation=Gtk.Orientation.HORIZONTAL, min=0, max=100, step=1)
-            self.bri_scale.connect("value-changed", self.set_bri)
+            self.bri_scale_handler = self.bri_scale.connect("value-changed", self.set_bri)
 
             inner_hbox.pack_start(self.bri_scale, True, True, 5)
             add_sep = True
@@ -368,7 +370,7 @@ class PopupWindow(Gtk.Window):
 
             self.vol_scale = Gtk.Scale.new_with_range(orientation=Gtk.Orientation.HORIZONTAL, min=0, max=100, step=1)
             self.vol_scale.set_value(self.parent.vol_value)
-            self.vol_scale.connect("value-changed", self.set_vol)
+            self.vol_scale_handler = self.vol_scale.connect("value-changed", self.set_vol)
 
             inner_hbox.pack_start(self.vol_scale, True, True, 5)
             if commands["pamixer"] and settings["output-switcher"]:
@@ -630,14 +632,16 @@ class PopupWindow(Gtk.Window):
                     update_image(self.vol_image, self.parent.vol_icon_name, self.icon_size, self.icons_path)
                     self.vol_icon_name = self.parent.vol_icon_name
 
-                self.vol_scale.set_value(self.parent.vol_value)
+                with self.vol_scale.handler_block(self.vol_scale_handler):
+                    self.vol_scale.set_value(self.parent.vol_value)
 
             if "brightness" in self.settings["components"]:
                 if self.parent.bri_icon_name != self.bri_icon_name:
                     update_image(self.bri_image, self.parent.bri_icon_name, self.icon_size, self.icons_path)
                     self.bri_icon_name = self.parent.bri_icon_name
 
-                self.bri_scale.set_value(self.parent.bri_value)
+                with self.bri_scale.handler_block(self.bri_scale_handler):
+                    self.bri_scale.set_value(self.parent.bri_value)
 
         return True
 

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -208,7 +208,7 @@ class Controls(Gtk.EventBox):
         volume = get_volume()
         if (self.vol_value, self.vol_muted != volume):
             icon_name = vol_icon_name(*volume)
-            
+
             if icon_name != self.vol_icon_name:
                 update_image(self.vol_image, icon_name, self.settings["icon-size"], self.icons_path)
                 self.vol_icon_name = icon_name
@@ -652,12 +652,12 @@ class PopupWindow(Gtk.Window):
         return True
 
     def set_bri(self, slider):
-        set_brightness(slider, self.settings["backlight-device"])
         self.parent.bri_value = int(slider.get_value())
+        set_brightness(self.parent.bri_value, self.settings["backlight-device"])
 
     def set_vol(self, slider):
-        set_volume(slider)
         self.parent.vol_value = int(slider.get_value())
+        set_volume(self.parent.vol_value)
 
     def close_win(self, w, e):
         self.hide()

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -395,8 +395,7 @@ def toggle_mute(*args):
         eprint("Couldn't toggle mute, 'pamixer' not found")
 
 
-def set_volume(slider):
-    percent = int(slider.get_value())
+def set_volume(percent):
     if nwg_panel.common.commands["pamixer"]:
         subprocess.call("pamixer --set-volume {}".format(percent).split())
     else:
@@ -426,22 +425,21 @@ def get_brightness(device=""):
     return brightness
 
 
-def set_brightness(slider, device=""):
-    value = int(slider.get_value())
-    if value == 0:
-        value = 1
+def set_brightness(percent, device=""):
+    if percent == 0:
+        percent = 1
     if nwg_panel.common.commands["light"]:
         if device:
-            subprocess.call("light -s {} -S {}".format(device, value).split())
+            subprocess.call("light -s {} -S {}".format(device, percent).split())
         else:
-            subprocess.call("light -S {}".format(value).split())
+            subprocess.call("light -S {}".format(percent).split())
     elif nwg_panel.common.commands["brightnessctl"]:
         if device:
-            subprocess.call("brightnessctl -d {} s {}%".format(device, value).split(),
+            subprocess.call("brightnessctl -d {} s {}%".format(device, percent).split(),
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.STDOUT)
         else:
-            subprocess.call("brightnessctl s {}%".format(value).split(),
+            subprocess.call("brightnessctl s {}%".format(percent).split(),
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.STDOUT)
     else:


### PR DESCRIPTION
#90 and #91 were related. Kind of. Both issues are resolved by adding context management to `refresh` method.

I added the [handler_block context manager](https://pygobject.readthedocs.io/en/latest/guide/api/signals.html?highlight=handler_block) to the parts where the `scale.set_value()` method is called. This prevents `set_value()` to emit the signal `value-changed` which again triggers `set_bri/vol()` which changes the `bri/vol_values` which ... you see. We get some kind of feedback-loop.

The first two commits are not required for this fix. But I think they are nice to have, feel free to undo them :smiley: if you want