### PR TITLE
Add taskbar setting to change the autotiling indicator

### DIFF
--- a/nwg_panel/modules/sway_taskbar.py
+++ b/nwg_panel/modules/sway_taskbar.py
@@ -81,7 +81,8 @@ class SwayTaskbar(Gtk.Box):
 class WorkspaceBox(Gtk.Box):
     def __init__(self, con, settings, autotiling):
         self.con = con
-        at_indicator = "a" if con.num in autotiling else ""
+        check_key(settings, "autotiling-indicator", "a")
+        at_indicator = settings["autotiling-indicator"] if con.num in autotiling else ""
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
 
         check_key(settings, "workspace-buttons", False)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.6.2',
+    version='0.6.3',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Allows the user to override 'a' as the autotiling indicator in the taskbar module.