### PR TITLE
Markers and minor bug fixes

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -88,6 +88,8 @@ SKELETON_PANEL: dict = {
         "show-layout": True,
         "workspace-buttons": True,
         "all-workspaces": True,
+        "mark-autotiling": True,
+        "mark-xwayland": True,
         "all-outputs": False
     },
     "sway-workspaces": {
@@ -879,6 +881,8 @@ class EditorWrapper(object):
             "show-layout": True,
             "workspace-buttons": True,
             "all-workspaces": True,
+            "mark-autotiling": True,
+            "mark-xwayland": True,
             "all-outputs": False
         }
         for key in defaults:
@@ -934,6 +938,12 @@ class EditorWrapper(object):
         self.ckb_all_workspaces = builder.get_object("all-workspaces")
         self.ckb_all_workspaces.set_active(settings["all-workspaces"])
 
+        self.ckb_mark_autotiling = builder.get_object("mark-autotiling")
+        self.ckb_mark_autotiling.set_active(settings["mark-autotiling"])
+
+        self.ckb_mark_xwayland = builder.get_object("mark-xwayland")
+        self.ckb_mark_xwayland.set_active(settings["mark-xwayland"])
+
         self.ckb_all_outputs = builder.get_object("all-outputs")
         self.ckb_all_outputs.set_active(settings["all-outputs"])
 
@@ -964,29 +974,21 @@ class EditorWrapper(object):
         if val is not None:
             settings["task-padding"] = int(val)
 
-        val = self.ckb_show_app_icon.get_active()
-        if val is not None:
-            settings["show-app-icon"] = val
+        settings["show-app-icon"] = self.ckb_show_app_icon.get_active()
 
-        val = self.ckb_show_app_name.get_active()
-        if val is not None:
-            settings["show-app-name"] = val
+        settings["show-app-name"] = self.ckb_show_app_name.get_active()
 
-        val = self.ckb_show_layout.get_active()
-        if val is not None:
-            settings["show-layout"] = val
+        settings["show-layout"] = self.ckb_show_layout.get_active()
 
-        val = self.workspace_buttons.get_active()
-        if val is not None:
-            settings["workspace-buttons"] = val
+        settings["workspace-buttons"] = self.workspace_buttons.get_active()
 
-        val = self.ckb_all_workspaces.get_active()
-        if val is not None:
-            settings["all-workspaces"] = val
+        settings["all-workspaces"] = self.ckb_all_workspaces.get_active()
 
-        val = self.ckb_all_outputs.get_active()
-        if val is not None:
-            settings["all-outputs"] = val
+        settings["mark-autotiling"] = self.ckb_mark_autotiling.get_active()
+
+        settings["mark-xwayland"] = self.ckb_mark_xwayland.get_active()
+
+        settings["all-outputs"] = self.ckb_all_outputs.get_active()
 
         save_json(self.config, self.file)
 

--- a/nwg_panel/config/config
+++ b/nwg_panel/config/config
@@ -95,6 +95,8 @@
       "show-layout": true,
       "workspace-buttons": false,
       "all-workspaces": true,
+      "mark-autotiling": true,
+      "mark-xwayland": true,
       "all-outputs": true
     },
     "sway-workspaces": {
@@ -212,6 +214,8 @@
       "show-layout": true,
       "workspace-buttons": false,
       "all-workspaces": true,
+      "mark-autotiling": true,
+      "mark-xwayland": true,
       "all-outputs": false
     },
     "sway-workspaces": {

--- a/nwg_panel/glade/config_sway_taskbar.glade
+++ b/nwg_panel/glade/config_sway_taskbar.glade
@@ -2,57 +2,19 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
-  <!-- n-columns=3 n-rows=9 -->
+  <!-- n-columns=3 n-rows=10 -->
   <object class="GtkGrid" id="grid">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
     <property name="row-spacing">10</property>
     <property name="column-spacing">10</property>
     <child>
-      <object class="GtkCheckButton" id="all-outputs">
-        <property name="label" translatable="yes">All outputs</property>
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="receives-default">False</property>
-        <property name="draw-indicator">True</property>
-      </object>
-      <packing>
-        <property name="left-attach">0</property>
-        <property name="top-attach">8</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkCheckButton" id="all-workspaces">
-        <property name="label" translatable="yes">All workspaces</property>
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="receives-default">False</property>
-        <property name="draw-indicator">True</property>
-      </object>
-      <packing>
-        <property name="left-attach">1</property>
-        <property name="top-attach">8</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkCheckButton" id="workspace-buttons">
-        <property name="label" translatable="yes">Workspaces as buttons</property>
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="receives-default">False</property>
-        <property name="draw-indicator">True</property>
-      </object>
-      <packing>
-        <property name="left-attach">1</property>
-        <property name="top-attach">7</property>
-      </packing>
-    </child>
-    <child>
       <object class="GtkCheckButton" id="show-layout">
         <property name="label" translatable="yes">Show layout</property>
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="receives-default">False</property>
+        <property name="halign">start</property>
         <property name="draw-indicator">True</property>
       </object>
       <packing>
@@ -66,6 +28,7 @@
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="receives-default">False</property>
+        <property name="halign">start</property>
         <property name="draw-indicator">True</property>
       </object>
       <packing>
@@ -79,6 +42,7 @@
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="receives-default">False</property>
+        <property name="halign">start</property>
         <property name="draw-indicator">True</property>
       </object>
       <packing>
@@ -182,6 +146,7 @@
         <property name="tooltip-text" translatable="yes">Space-separated numbers of workspaces 
 you defined in sway config. We'll build the 
 context menu out of them.</property>
+        <property name="halign">start</property>
         <property name="stock">gtk-about</property>
       </object>
       <packing>
@@ -226,6 +191,79 @@ context menu out of them.</property>
         <property name="top-attach">0</property>
         <property name="width">3</property>
       </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="all-outputs">
+        <property name="label" translatable="yes">All outputs</property>
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
+        <property name="halign">start</property>
+        <property name="draw-indicator">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">9</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="all-workspaces">
+        <property name="label" translatable="yes">All workspaces</property>
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
+        <property name="halign">start</property>
+        <property name="draw-indicator">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">9</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="workspace-buttons">
+        <property name="label" translatable="yes">Workspaces as buttons</property>
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
+        <property name="halign">start</property>
+        <property name="draw-indicator">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">8</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="mark-autotiling">
+        <property name="label" translatable="yes">Mark autotiling</property>
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
+        <property name="halign">start</property>
+        <property name="draw-indicator">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">1</property>
+        <property name="top-attach">7</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkCheckButton" id="mark-xwayland">
+        <property name="label" translatable="yes">Mark Xwayland</property>
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
+        <property name="halign">start</property>
+        <property name="draw-indicator">True</property>
+      </object>
+      <packing>
+        <property name="left-attach">0</property>
+        <property name="top-attach">8</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
     </child>
     <child>
       <placeholder/>

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -378,8 +378,14 @@ def main():
     panels = panels + to_append
 
     for panel in panels:
-        if panel["output"] and panel["output"] not in common.outputs:
-            print("Output '{}' not found".format(panel["output"]))
+        monitor = None
+        try:
+            monitor = common.outputs[panel["output"]]["monitor"]
+        except KeyError:
+            pass
+
+        if panel["output"] and not monitor:
+            print("Couldn't assign a Gdk.Monitor to output '{}'".format(panel["output"]))
             continue
 
         check_key(panel, "icons", "")

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -378,6 +378,10 @@ def main():
     panels = panels + to_append
 
     for panel in panels:
+        if panel["output"] and panel["output"] not in common.outputs:
+            print("Output '{}' not found".format(panel["output"]))
+            continue
+
         check_key(panel, "icons", "")
         icons_path = ""
         if panel["icons"] == "light":

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -59,7 +59,7 @@ try:
 
     tray_available = True
 except:
-    print("Couldn't load system tray, is 'python-dbus' installed?", file=sys.stderr)
+    print("Couldn't load system tray, is 'python-dasbus' installed?", file=sys.stderr)
 
 sway = os.getenv('SWAYSOCK') is not None
 if sway:

--- a/nwg_panel/modules/sway_taskbar.py
+++ b/nwg_panel/modules/sway_taskbar.py
@@ -158,6 +158,8 @@ class WindowBox(Gtk.EventBox):
         if con.name:
             check_key(settings, "show-app-name", True)
             name = con.name[:settings["name-max-len"]] if len(con.name) > settings["name-max-len"] else con.name
+            if settings["mark-xwayland"] and not con.app_id:
+                name = "X|" + name
             if settings["show-app-name"]:
                 check_key(settings, "name-max-len", 10)
                 label = Gtk.Label(name)

--- a/nwg_panel/modules/sway_taskbar.py
+++ b/nwg_panel/modules/sway_taskbar.py
@@ -16,6 +16,8 @@ class SwayTaskbar(Gtk.Box):
         check_key(settings, "workspace-menu", [1, 2, 3, 4, 5, 6, 7, 8])
         check_key(settings, "task-padding", 0)
         check_key(settings, "all-workspaces", True)
+        check_key(settings, "mark-autotiling", True)
+        check_key(settings, "mark-xwayland", True)
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=settings["workspaces-spacing"])
         self.settings = settings
         self.display_name = display_name
@@ -23,7 +25,7 @@ class SwayTaskbar(Gtk.Box):
         self.tree = i3.get_tree()
         self.displays_tree = self.list_tree()
 
-        self.autotiling = load_autotiling()
+        self.autotiling = load_autotiling() if settings["mark-autotiling"] else []
 
         self.build_box()
         self.ipc_data = {}

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.6.2',
+    version='0.6.3',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- fixed improper error message on `python-dasbus` module missing; Closes #99
- added check if Gdk.Monitor detected: if not, the panel instance won't be created
- [SwayTaskbar] added switch to turn the (a)utotiling marker on/off; Closes #100
- [SwayTaskbar] added switchable X|wayland marker