### PR TITLE
add systemd service

### DIFF
--- a/nwg-panel.service
+++ b/nwg-panel.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=GTK3-based panel for sway window manager
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecCondition=/bin/sh -c '[ -n "$WAYLAND_DISPLAY" ]'
+ExecStart=/usr/bin/nwg-panel
+Restart=always
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
Not all sway users rely on the "flaky" `exec_always` in the sway config.

For example if the app crashes (like it currently does on my machine
after a suspend / resume), then `nwg-panel` is terminated and never
comes back.

For users using [sway-service](https://github.com/xdbob/sway-services)
this would be a nice addition.

Also this is the required change in the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=nwg-panel)

```diff
diff --git a/PKGBUILD b/PKGBUILD
index 26c5832..f698201 100644
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,4 +20,5 @@ package() {
   install -D -t "$pkgdir"/usr/share/pixmaps nwg-panel.svg
   install -D -t "$pkgdir"/usr/share/pixmaps nwg-shell.svg
   install -D -t "$pkgdir"/usr/share/applications nwg-panel-config.desktop
+  install -D -t "$pkgdir"/usr/lib/systemd/user/ nwg-panel.service
 }
```