### PR TITLE
ddcutil support for external display brightness control

### DIFF
--- a/nwg_panel/common.py
+++ b/nwg_panel/common.py
@@ -23,6 +23,7 @@ name2icon_dict = {}
 commands = {
     "light": False,
     "brightnessctl": False,
+    "ddcutil": False,
     "pamixer": False,
     "pactl": False,
     "playerctl": False,

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -2549,6 +2549,7 @@ class EditorWrapper(object):
             },
             "show-values": False,
             "output-switcher": False,
+            "backlight-controller": "light",
             "backlight-device": "",
             "interval": 1,
             "window-width": 0,
@@ -2599,6 +2600,9 @@ class EditorWrapper(object):
 
         self.ctrl_comp_brightness = builder.get_object("ctrl-comp-brightness")
         self.ctrl_comp_brightness.set_active("brightness" in settings["components"])
+
+        self.ctrl_backlight_controller = builder.get_object("backlight-controller")
+        self.ctrl_backlight_controller.set_active_id(settings["backlight-controller"])
 
         self.ctrl_backlight_device = builder.get_object("backlight-device")
         self.ctrl_backlight_device.set_text(settings["backlight-device"])
@@ -2699,6 +2703,8 @@ class EditorWrapper(object):
         else:
             if "brightness" in settings["components"]:
                 settings["components"].remove("brightness")
+
+        settings["backlight-controller"] = self.ctrl_backlight_controller.get_active_id()
 
         settings["backlight-device"] = self.ctrl_backlight_device.get_text()
 

--- a/nwg_panel/glade/config_controls.glade
+++ b/nwg_panel/glade/config_controls.glade
@@ -8,7 +8,7 @@
     <property name="label-xalign">0.5</property>
     <property name="shadow-type">out</property>
     <child>
-      <!-- n-columns=4 n-rows=15 -->
+      <!-- n-columns=5 n-rows=15 -->
       <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -221,19 +221,6 @@ Depends on `python-netifaces`.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Depends on `light` or `brightnessctl`.</property>
-            <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">1</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkCheckButton" id="ctrl-comp-brightness">
             <property name="label" translatable="yes">Brightness</property>
             <property name="visible">True</property>
@@ -363,34 +350,6 @@ Depends on `python-netifaces`.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkEntry" id="backlight-device">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="placeholder-text" translatable="yes">backlight device</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Backlight device path (for 'light')
-or name (for 'brightnessctl').
-Use 'light -L' or 'brightnessctl -l'
-to check available devices.
-LEAVE BLANK IF EVERYTHING WORKS</property>
-            <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">3</property>
-            <property name="top-attach">1</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -493,6 +452,104 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="left-attach">2</property>
             <property name="top-attach">10</property>
           </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Depends on `light` or `brightnessctl`.</property>
+            <property name="halign">start</property>
+            <property name="stock">gtk-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Backlight device path (for 'light')
+or name (for 'brightnessctl').
+Use 'light -L' or 'brightnessctl -l'
+to check available devices.
+LEAVE BLANK IF EVERYTHING WORKS</property>
+            <property name="halign">start</property>
+            <property name="stock">gtk-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">4</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="backlight-device">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="placeholder-text" translatable="yes">backlight device</property>
+          </object>
+          <packing>
+            <property name="left-attach">3</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="backlight-controller">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <items>
+              <item id="light" translatable="yes">light</item>
+              <item id="brightnessctl" translatable="yes">brightnessctl</item>
+              <item id="ddcutil" translatable="yes">ddcutil</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/glade/config_controls.glade
+++ b/nwg_panel/glade/config_controls.glade
@@ -471,9 +471,11 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Backlight device path (for 'light')
-or name (for 'brightnessctl').
+or name (for 'brightnessctl')
+or I2C bus number (for 'ddcutil').
 Use 'light -L' or 'brightnessctl -l'
-to check available devices.
+or 'ddcutil --help' to
+check available devices.
 LEAVE BLANK IF EVERYTHING WORKS</property>
             <property name="halign">start</property>
             <property name="stock">gtk-about</property>

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -194,7 +194,7 @@ class Controls(Gtk.EventBox):
             self.bt_label.set_text(name)
 
     def update_brightness(self):
-        value = get_brightness(device=self.settings["backlight-device"])
+        value = get_brightness(device=self.settings["backlight-device"], controller=self.settings["backlight-controller"])
         if self.bri_value != value:
             icon_name = bri_icon_name(value)
 
@@ -272,6 +272,7 @@ class PopupWindow(Gtk.Window):
         if monitor:
             GtkLayerShell.set_monitor(self, monitor)
 
+        check_key(settings, "backlight-controller", "light")
         check_key(settings, "backlight-device", "")
 
         check_key(settings, "css-name", "controls-window")
@@ -690,7 +691,7 @@ class PopupWindow(Gtk.Window):
 
     def set_bri(self, slider):
         self.parent.bri_value = int(slider.get_value())
-        set_brightness(self.parent.bri_value, self.settings["backlight-device"])
+        set_brightness(self.parent.bri_value, device=self.settings["backlight-device"], controller=self.settings["backlight-controller"])
 
     def set_vol(self, slider):
         self.parent.vol_value = int(slider.get_value())

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -423,16 +423,16 @@ def set_volume(percent):
         eprint("Couldn't set volume, 'pamixer' not found")
 
 
-def get_brightness(device=""):
+def get_brightness(device="", controller=""):
     brightness = 0
-    if nwg_panel.common.commands["light"]:
+    if nwg_panel.common.commands["light"] and controller == "light":
         try:
             cmd = "light -G -s {}".format(device) if device else "light -G"
             output = cmd2string(cmd)
             brightness = int(round(float(output), 0))
         except:
             pass
-    elif nwg_panel.common.commands["brightnessctl"]:
+    elif nwg_panel.common.commands["brightnessctl"] and controller == "brightnessctl":
         try:
             cmd = "brightnessctl g -d {}".format(device) if device else "brightnessctl g"
             output = cmd2string(cmd)
@@ -440,21 +440,29 @@ def get_brightness(device=""):
             brightness = int(round(float(b), 0))
         except:
             pass
+    elif nwg_panel.common.commands["ddcutil"] and controller == "ddcutil":
+        try:
+            cmd = "ddcutil --sleep-multiplier=.01 --noverify getvcp 10 --bus={}".format(device) if device else "ddcutil --sleep-multiplier=.01 --noverify getvcp 10"
+            output = cmd2string(cmd)
+            b = int(output.split("current value =")[1].split(",")[0])
+            brightness = int(round(float(b), 0))
+        except:
+            pass
     else:
-        eprint("Couldn't get brightness, is 'light' or 'brightnessctl' installed?")
+        eprint("Couldn't get brightness, is 'light' or 'brightnessctl' or 'ddcutil' installed?")
 
     return brightness
 
 
-def set_brightness(percent, device=""):
+def set_brightness(percent, device="", controller=""):
     if percent == 0:
         percent = 1
-    if nwg_panel.common.commands["light"]:
+    if controller == "light":
         if device:
             subprocess.call("light -s {} -S {}".format(device, percent).split())
         else:
             subprocess.call("light -S {}".format(percent).split())
-    elif nwg_panel.common.commands["brightnessctl"]:
+    elif nwg_panel.common.commands["brightnessctl"] and controller == "brightnessctl":
         if device:
             subprocess.call("brightnessctl -d {} s {}%".format(device, percent).split(),
                             stdout=subprocess.DEVNULL,
@@ -463,6 +471,11 @@ def set_brightness(percent, device=""):
             subprocess.call("brightnessctl s {}%".format(percent).split(),
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.STDOUT)
+    elif nwg_panel.common.commands["ddcutil"] and controller == "ddcutil":
+        if device:
+            subprocess.call("ddcutil --sleep-multiplier=.01 --noverify setvcp 10 {} --bus={}".format(percent, device).split())
+        else:
+            subprocess.call("ddcutil --sleep-multiplier=.01 --noverify setvcp 10 {}".format(percent).split())
     else:
         eprint("Either 'light' or 'brightnessctl' package required")
 

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -457,7 +457,7 @@ def get_brightness(device="", controller=""):
 def set_brightness(percent, device="", controller=""):
     if percent == 0:
         percent = 1
-    if controller == "light":
+    if nwg_panel.common.commands["light"] and controller == "light":
         if device:
             subprocess.call("light -s {} -S {}".format(device, percent).split())
         else:
@@ -477,7 +477,7 @@ def set_brightness(percent, device="", controller=""):
         else:
             subprocess.call("ddcutil --sleep-multiplier=.01 --noverify setvcp 10 {}".format(percent).split())
     else:
-        eprint("Either 'light' or 'brightnessctl' package required")
+        eprint("Either 'light' or 'brightnessctl' or 'ddcutil' package required")
 
 
 def get_battery():


### PR DESCRIPTION
add `ddcutil` in addition to `light` and `brightnessctl` to allow controlling brightness for external monitors