### PR TITLE
Update icons in markup to be Adwaita conformant

### DIFF
--- a/nwg_panel/glade/config_brightness_slider.glade
+++ b/nwg_panel/glade/config_brightness_slider.glade
@@ -139,7 +139,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Slider popup window width in pixels; leave 0 for auto.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">3</property>
@@ -332,7 +332,7 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Number of seconds between every update.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">3</property>
@@ -346,7 +346,7 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="tooltip-text" translatable="yes">Value of increment/decrement using scroll wheel.
 0 to disable.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">3</property>
@@ -373,7 +373,7 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="tooltip-text" translatable="yes">the angle that the baseline of the label makes with 
 the horizontal, in degrees, measured counterclockwise</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">3</property>
@@ -412,7 +412,7 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">For widget on panel.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">3</property>
@@ -425,7 +425,7 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">For slider popup window.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">3</property>
@@ -460,7 +460,7 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Slider popup window height in pixels; leave 0 for auto.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">3</property>
@@ -561,7 +561,7 @@ or 'ddcutil --help' to
 check available devices.
 LEAVE BLANK IF EVERYTHING WORKS</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">1</property>

--- a/nwg_panel/glade/config_button.glade
+++ b/nwg_panel/glade/config_button.glade
@@ -180,7 +180,7 @@
             <property name="tooltip-text" translatable="yes">Attention! Renaming an existing
 button will create a new one.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-dialog-warning</property>
+            <property name="icon-name">dialog-warning</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_controls.glade
+++ b/nwg_panel/glade/config_controls.glade
@@ -81,7 +81,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Depends on `python-psutil`.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">1</property>
@@ -119,7 +119,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Depends on `bluez-utils`.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">1</property>
@@ -172,7 +172,7 @@ use `ifconfig` to check names,
 e.g. `enp6s0`or `wlo1`.
 Depends on `python-netifaces`.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">1</property>
@@ -199,7 +199,7 @@ Depends on `python-netifaces`.</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Depends on the `pamixer` package.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">1</property>
@@ -252,7 +252,7 @@ Depends on `python-netifaces`.</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Controls window width in pixels; leave 0 for auto.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">3</property>
@@ -459,7 +459,7 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Depends on `light` or `brightnessctl`.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">1</property>
@@ -478,7 +478,7 @@ or 'ddcutil --help' to
 check available devices.
 LEAVE BLANK IF EVERYTHING WORKS</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">4</property>

--- a/nwg_panel/glade/config_dwl_tags.glade
+++ b/nwg_panel/glade/config_dwl_tags.glade
@@ -57,7 +57,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Space-separated names  for tags 1 - 9</property>
             <property name="double-buffered">False</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_executor.glade
+++ b/nwg_panel/glade/config_executor.glade
@@ -202,7 +202,7 @@
 an icon name / path and a label 
 in 1 or 2 lines of text. See Wiki 
 for details.</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>
@@ -238,7 +238,7 @@ for details.</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Attention! Renaming an existing
 executor will create a new one.</property>
-            <property name="stock">gtk-dialog-warning</property>
+            <property name="icon-name">dialog-warning</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_menu_start.glade
+++ b/nwg_panel/glade/config_menu_start.glade
@@ -399,7 +399,7 @@ icon size:</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Leave 0 for auto-detection</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>
@@ -412,7 +412,7 @@ icon size:</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Leave 0 for auto-detection</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_openweather.glade
+++ b/nwg_panel/glade/config_openweather.glade
@@ -475,7 +475,7 @@ you may define your own label here.</property>
 by Dovora interactive https://www.dovora.com
 Creative Commons Attribution-ShareAlike 4.0</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_playerctl.glade
+++ b/nwg_panel/glade/config_playerctl.glade
@@ -55,7 +55,7 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Optional name for use in the css file</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>
@@ -79,7 +79,7 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Optional name for use in the css file</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_scratchpad.glade
+++ b/nwg_panel/glade/config_scratchpad.glade
@@ -33,7 +33,7 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Optional name for use in the css file</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_sway_taskbar.glade
+++ b/nwg_panel/glade/config_sway_taskbar.glade
@@ -157,7 +157,7 @@
 you defined in sway config. We'll build the 
 context menu out of them.</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_sway_workspaces.glade
+++ b/nwg_panel/glade/config_sway_workspaces.glade
@@ -26,7 +26,7 @@
 of workspaces to show</property>
             <property name="double-buffered">False</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>
@@ -252,7 +252,7 @@ for each workspace
 number specified above</property>
             <property name="double-buffered">False</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>
@@ -269,7 +269,7 @@ for each workspace
 number specified above</property>
             <property name="double-buffered">False</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>

--- a/nwg_panel/glade/config_swaync.glade
+++ b/nwg_panel/glade/config_swaync.glade
@@ -73,7 +73,7 @@
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">toggles Notification Center on/off</property>
             <property name="halign">start</property>
-            <property name="stock">gtk-about</property>
+            <property name="icon-name">help-about</property>
           </object>
           <packing>
             <property name="left-attach">2</property>


### PR DESCRIPTION
Updating a couple more icons in the config app to use names present in Adwaita