### PR TITLE
heterogeneous panels; metadata scrolling in Playerctl module

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -123,6 +123,7 @@ SKELETON_PANEL: dict = {
         "buttons-position": "left",
         "icon-size": 16,
         "chars": 30,
+        "scroll": False,
         "button-css-name": "",
         "label-css-name": "",
         "interval": 1
@@ -1406,6 +1407,7 @@ class EditorWrapper(object):
             "buttons-position": "left",
             "icon-size": 16,
             "chars": 30,
+            "scroll": False,
             "button-css-name": "",
             "label-css-name": "",
             "interval": 1,
@@ -1431,6 +1433,9 @@ class EditorWrapper(object):
         adj = Gtk.Adjustment(value=0, lower=1, upper=256, step_increment=1, page_increment=10, page_size=1)
         self.sc_chars.configure(adj, 1, 0)
         self.sc_chars.set_value(settings["chars"])
+
+        self.cb_scroll = builder.get_object("scroll")
+        self.cb_scroll.set_active(settings["scroll"])
 
         self.sc_interval_playerctl = builder.get_object("interval")
         self.sc_interval_playerctl.set_numeric(True)
@@ -1460,6 +1465,7 @@ class EditorWrapper(object):
 
         settings["icon-size"] = int(self.sc_icon_size_playerctl.get_value())
         settings["chars"] = int(self.sc_chars.get_value())
+        settings["scroll"] = self.cb_scroll.get_active()
 
         settings["button-css-name"] = self.eb_button_css_name.get_text()
         settings["label-css-name"] = self.eb_label_css_name.get_text()
@@ -1841,7 +1847,7 @@ class EditorWrapper(object):
             "show-cloudiness": True,
             "show-visibility": True,
             "show-pop": True,
-            "show-volume":True
+            "show-volume": True
         }
         for key in defaults:
             check_key(settings, key, defaults[key])
@@ -2045,7 +2051,7 @@ class EditorWrapper(object):
         settings["show-volume"] = self.ow_show_volume.get_active()
 
         save_json(self.config, self.file)
-    
+
     def edit_brightness_slider(self, *args):
         self.load_panel()
         self.edited = "brightness-slider"
@@ -2098,14 +2104,14 @@ class EditorWrapper(object):
             elif type(widget) in [Gtk.ComboBoxText, Gtk.ComboBox]:
                 widget.set_active_id(str(value))
             self.brightness_slider_config[setting] = widget
-        
+
         for item in self.scrolled_window.get_children():
             item.destroy()
         self.scrolled_window.add(frame)
 
     def update_brightness_slider(self):
         settings = self.panel["brightness-slider"]
-        
+
         for setting, widget in self.brightness_slider_config.items():
             if type(widget) == Gtk.Entry:
                 value = widget.get_text()

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -679,6 +679,7 @@ class EditorWrapper(object):
             "spacing": 0,
             "icons": "",
             "css-name": "",
+            "homogeneous": True,
             "exclusive-zone": True
         }
         for key in defaults:
@@ -807,6 +808,9 @@ class EditorWrapper(object):
         self.eb_css_name = builder.get_object("css-name")
         self.eb_css_name.set_text(self.panel["css-name"])
 
+        self.cb_homogeneous = builder.get_object("homogeneous")
+        self.cb_homogeneous.set_active(self.panel["homogeneous"])
+
         self.cb_exclusive_zone = builder.get_object("exclusive-zone")
         self.cb_exclusive_zone.set_active(self.panel["exclusive-zone"])
 
@@ -894,6 +898,8 @@ class EditorWrapper(object):
 
         val = self.eb_css_name.get_text()
         self.panel["css-name"] = val
+
+        self.panel["homogeneous"] = self.cb_homogeneous.get_active()
 
         self.panel["exclusive-zone"] = self.cb_exclusive_zone.get_active()
 

--- a/nwg_panel/config/config
+++ b/nwg_panel/config/config
@@ -127,6 +127,7 @@
       "buttons-position": "left",
       "icon-size": 16,
       "chars": 30,
+      "scroll": false,
       "button-css-name": "",
       "label-css-name": "",
       "interval": 1
@@ -246,6 +247,7 @@
       "buttons-position": "left",
       "icon-size": 16,
       "chars": 30,
+      "scroll": false,
       "button-css-name": "",
       "label-css-name": "",
       "interval": 1

--- a/nwg_panel/config/config
+++ b/nwg_panel/config/config
@@ -7,6 +7,7 @@
     "controls": "right",
     "width": "auto",
     "height": 30,
+    "homogeneous": true,
     "margin-top": 0,
     "margin-bottom": 0,
     "padding-horizontal": 0,

--- a/nwg_panel/glade/config_panel.glade
+++ b/nwg_panel/glade/config_panel.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkFrame" id="frame">
@@ -421,8 +421,7 @@ be placed on the same layer.</property>
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
-            <property name="tooltip-text" translatable="yes">determins whether the panel is to
-put other windows away</property>
+            <property name="tooltip-text" translatable="yes">determins whether the panel is to put other windows away</property>
             <property name="draw-indicator">True</property>
           </object>
           <packing>
@@ -431,7 +430,18 @@ put other windows away</property>
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkCheckButton" id="homogeneous">
+            <property name="label" translatable="yes">homogeneous</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="tooltip-text" translatable="yes">sets equal columns width by default if 'Modules center' not empty</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">15</property>
+          </packing>
         </child>
       </object>
     </child>

--- a/nwg_panel/glade/config_playerctl.glade
+++ b/nwg_panel/glade/config_playerctl.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkFrame" id="frame">
@@ -55,6 +55,7 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Optional name for use in the css file</property>
+            <property name="halign">start</property>
             <property name="icon-name">help-about</property>
           </object>
           <packing>
@@ -79,6 +80,7 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="tooltip-text" translatable="yes">Optional name for use in the css file</property>
+            <property name="halign">start</property>
             <property name="icon-name">help-about</property>
           </object>
           <packing>
@@ -206,7 +208,18 @@
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkCheckButton" id="scroll">
+            <property name="label" translatable="yes">scroll</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="tooltip-text" translatable="yes">Determines if to shorten too long text or scroll it.</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">3</property>
+          </packing>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -497,19 +497,13 @@ def main():
             check_key(panel, "modules-left", [])
             check_key(panel, "modules-center", [])
             check_key(panel, "modules-right", [])
-
-            # This is to allow the "auto" value. Actually all non-numeric values will be removed.
-            if "homogeneous" in panel and not isinstance(panel["homogeneous"], bool):
-                panel.pop("homogeneous")
-
-            # set equal columns width by default if "modules-center" not empty; this may be overridden in config
-            if panel["modules-center"]:
-                check_key(panel, "homogeneous", True)
-            else:
-                check_key(panel, "homogeneous", False)
+            check_key(panel, "homogeneous", True)
 
             inner_box = Gtk.Box(orientation=o, spacing=0)
-            inner_box.set_homogeneous(panel["homogeneous"])
+
+            # set equal columns width by default if "modules-center" not empty; this may be overridden in config
+            if panel["modules-center"] and panel["homogeneous"]:
+                inner_box.set_homogeneous(True)
 
             hbox.pack_start(inner_box, True, True, 0)
             hbox.set_property("margin-start", panel["padding-horizontal"])

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.7.8',
+    version='0.7.9',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- added (back) switch to disable panel homogeneity: closes #95
- Playerctl: added possibility to scroll track metadata longer than the label length limit (instead of shortening).