### PR TITLE
Add setting for Order by PID, to show earlier PID first in taskbar

### DIFF
--- a/nwg_panel/modules/sway_taskbar.py
+++ b/nwg_panel/modules/sway_taskbar.py
@@ -19,6 +19,7 @@ class SwayTaskbar(Gtk.Box):
         check_key(settings, "mark-autotiling", True)
         check_key(settings, "mark-xwayland", True)
         check_key(settings, "angle", 0.0)
+        check_key(settings, "order-by-pid", False)
 
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=settings["workspaces-spacing"])
         self.settings = settings
@@ -71,7 +72,11 @@ class SwayTaskbar(Gtk.Box):
                 if desc.type == "workspace":
                     self.ws_box = WorkspaceBox(desc, self.settings, self.autotiling)
                     if all_workspaces or desc.find_focused() is not None:
-                        for con in desc.descendants():
+                        descendants = desc.descendants()
+                        # Setting to sort by PID, where the earliest PID shows first.
+                        if self.settings["order-by-pid"]:
+                            descendants = sorted(descendants, key=lambda c: c.pid)
+                        for con in descendants:
                             if con.name or con.app_id:
                                 win_box = WindowBox(con, self.settings, self.position, self.icons_path, floating=con in desc.floating_nodes)
                                 self.ws_box.pack_start(win_box, False, False, self.settings["task-padding"])


### PR DESCRIPTION
Hi!

This is a great program, thanks! The code is also laid out really well and made editing super easy :heart_eyes: 

In other panels, you usually have the following options when displaying a taskbar:

1. Order by PID (Also called order by timestamp, KDE Plasma calls it "Do not sort")
2. Manual ordering (sorting, this would be amazing..)
3. Alphabetical

I think the way Windows works is by last opened, then reordering as needed (I haven't used Windows in ages, but I believe the default is earliest program first, as well as manual ordering)?

This PR adds the first option, which is Order by PID.

Ideally I would like to have the 3 options instead of just this option as I have done in the PR, and the option to turn off the feature where it shows the current window as the last/selected item, as it's distracting (IMHO, hence a setting to opt-out :)) when this happens when you change windows frequently.

What are you thoughts on this approach? I would be happy to help implement this.

P.S: I couldn't figure out glade (and manually editing wasn't rendering properly), so apologies for not including that file).