### PR TITLE
Background window for the Controls popup

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -53,8 +53,9 @@ SKELETON_PANEL: dict = {
         "show-values": False,
         "interval": 1,
         "icon-size": 16,
-        "hover-opens": True,
+        "hover-opens": False,
         "leave-closes": True,
+        "click-closes": False,
         "root-css-name": "controls-overview",
         "css-name": "controls-window",
         "net-interface": "",
@@ -2747,8 +2748,9 @@ class EditorWrapper(object):
             "window-margin-horizontal": 0,
             "window-margin-vertical": 0,
             "icon-size": 16,
-            "hover-opens": True,
+            "hover-opens": False,
             "leave-closes": True,
+            "click-closes": False,
             "root-css-name": "controls-overview",
             "css-name": "controls-window",
             "net-interface": "",
@@ -2878,6 +2880,9 @@ class EditorWrapper(object):
         self.ctrl_leave_closes = builder.get_object("leave-closes")
         self.ctrl_leave_closes.set_active(settings["leave-closes"])
 
+        self.ctrl_click_closes = builder.get_object("click-closes")
+        self.ctrl_click_closes.set_active(settings["click-closes"])
+
         self.ctrl_angle = builder.get_object("angle")
         self.ctrl_angle.set_active_id(str(settings["angle"]))
 
@@ -2945,6 +2950,7 @@ class EditorWrapper(object):
         settings["show-values"] = self.ctrl_show_values.get_active()
         settings["hover-opens"] = self.ctrl_hover_opens.get_active()
         settings["leave-closes"] = self.ctrl_leave_closes.get_active()
+        settings["click-closes"] = self.ctrl_click_closes.get_active()
 
         try:
             settings["angle"] = float(self.ctrl_angle.get_active_id())

--- a/nwg_panel/config/config
+++ b/nwg_panel/config/config
@@ -38,8 +38,9 @@
       "show-values": false,
       "interval": 1,
       "icon-size": 16,
-      "hover-opens": true,
+      "hover-opens": false,
       "leave-closes": true,
+      "click-closes": false,
       "css-name": "controls-window",
       "net-interface": "",
       "custom-items": [
@@ -179,8 +180,9 @@
       "show-values": false,
       "interval": 1,
       "icon-size": 16,
-      "hover-opens": true,
+      "hover-opens": false,
       "leave-closes": true,
+      "click-closes": false,
       "css-name": "controls-window",
       "net-interface": "",
       "custom-items": [

--- a/nwg_panel/glade/config_controls.glade
+++ b/nwg_panel/glade/config_controls.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.24"/>
   <object class="GtkFrame" id="frame">
@@ -8,7 +8,7 @@
     <property name="label-xalign">0.5</property>
     <property name="shadow-type">out</property>
     <child>
-      <!-- n-columns=5 n-rows=15 -->
+      <!-- n-columns=5 n-rows=16 -->
       <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -350,59 +350,6 @@ Depends on `python-netifaces`.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <child>
-              <object class="GtkCheckButton" id="show-values">
-                <property name="label" translatable="yes">Values in widget</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="draw-indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="hover-opens">
-                <property name="label" translatable="yes">Hover opens</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="draw-indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="leave-closes">
-                <property name="label" translatable="yes">Leave closes</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="draw-indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">14</property>
-            <property name="width">4</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkComboBoxText" id="angle">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -510,6 +457,89 @@ LEAVE BLANK IF EVERYTHING WORKS</property>
             <property name="left-attach">2</property>
             <property name="top-attach">1</property>
           </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkCheckButton" id="hover-opens">
+                <property name="label" translatable="yes">Widget hover opens</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Determins if to open the Controls window
+on panel Controls widget pointed</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="leave-closes">
+                <property name="label" translatable="yes">Window leave closes</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Determins if to close the Controls
+window when left</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="click-closes">
+                <property name="label" translatable="yes">Click outside closes</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Determins if to close the Controls
+window on mouse click outside it</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">15</property>
+            <property name="width">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="show-values">
+            <property name="label" translatable="yes">Values in widget</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="tooltip-text" translatable="yes">Determins if show the Controls
+values in the panel widget</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">14</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -118,7 +118,7 @@ def check_tree():
 
             for item in common.controls_list:
                 if item.popup_window.get_visible():
-                    item.popup_window.hide()
+                    item.popup_window.hide_and_clear_tag()
 
         common.ipc_data = tree.ipc_data
 
@@ -375,6 +375,11 @@ def main():
         provider.load_from_path(os.path.join(common.config_dir, args.style))
     except Exception as e:
         print(e, file=sys.stderr)
+
+    # Controls background window (invisible): add style missing from the css file
+    css = provider.to_string().encode('utf-8')
+    css += b""" window#bcg-window { background-color: rgba(0, 0, 0, 0.15); } """
+    provider.load_from_data(css)
 
     # Mirror bars to all outputs #48 (if panel["output"] == "All")
     to_remove = []

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -378,7 +378,7 @@ def main():
 
     # Controls background window (invisible): add style missing from the css file
     css = provider.to_string().encode('utf-8')
-    css += b""" window#bcg-window { background-color: rgba(0, 0, 0, 0.15); } """
+    css += b""" window#bcg-window { background-color: rgba(0, 0, 0, 0.2); } """
     provider.load_from_data(css)
 
     # Mirror bars to all outputs #48 (if panel["output"] == "All")


### PR DESCRIPTION
[optionally] allows to display a semi-transparent (0.15) background window, that closes the popup on 'button-release-event' and ipc_data changed.