### PR TITLE
restart switch and delay

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2022 Piotr Miller & Contributors
+Copyright (c) 2021-2023 Piotr Miller & Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -269,7 +269,7 @@ def build_common_settings_window():
 
     sb = Gtk.SpinButton.new_with_range(0, 30000, 100)
     sb.set_value(common_settings["restart-delay"])
-    sb.connect("changed", on_restart_delay_changed)
+    sb.connect("value-changed", on_restart_delay_changed)
     sb.set_tooltip_text("If, after turning a display off and back on, panels don't appear on it, it may mean\n"
                         "the display responds too slowly (e.g. if turned via HDMI). Try adding some delay.\n"
                         "Starting from 500 ms may be a good idea.")

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -213,15 +213,43 @@ def rt_sig_handler(sig, frame):
     print("{} RT signal received".format(sig))
 
 
-
 def handle_keyboard(window, event):
     if event.type == Gdk.EventType.KEY_RELEASE and event.keyval == Gdk.KEY_Escape:
         window.close()
 
 
+def build_common_settings_window():
+    win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
+    # win.connect("key-release-event", handle_keyboard)
+    # win.connect('destroy', Gtk.main_quit)
+
+    vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
+    vbox.set_property("margin", 6)
+    win.add(vbox)
+
+    frame = Gtk.Frame()
+    frame.set_label("nwg-panel: Common settings")
+    vbox.pack_start(frame, True, True, 6)
+
+    hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
+    vbox.pack_start(hbox, False, False, 6)
+    btn = Gtk.Button.new_with_label("Close")
+    btn.connect("clicked", close_common_settings, win)
+    hbox.pack_end(btn, False, False, 6)
+
+    win.show_all()
+
+    return win
+
+
+def close_common_settings(btn, window):
+    window.close()
+
+
 class PanelSelector(Gtk.Window):
     def __init__(self):
         super(PanelSelector, self).__init__()
+        self.common_settings_window = None
         self.to_delete = []
         self.connect("key-release-event", handle_keyboard)
         self.connect('destroy', Gtk.main_quit)
@@ -270,14 +298,20 @@ class PanelSelector(Gtk.Window):
         inner_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         hbox.pack_start(inner_hbox, True, True, 12)
 
+        btn = Gtk.Button.new_with_label("Settings")
+        btn.set_tooltip_text("Common nwg-panel settings")
+        btn.connect("clicked", self.show_common_settings)
+        inner_hbox.pack_start(btn, False, False, 3)
+
         label = Gtk.Label()
         label.set_text("New file:")
         label.set_halign(Gtk.Align.START)
-        inner_hbox.pack_start(label, False, False, 6)
+        inner_hbox.pack_start(label, False, False, 3)
 
         self.new_file_entry = Gtk.Entry()
         self.new_file_entry.set_width_chars(15)
         self.new_file_entry.set_placeholder_text("filename")
+        self.new_file_entry.set_tooltip_text("New panel config file name")
         self.new_file_entry.connect("changed", validate_name)
         inner_hbox.pack_start(self.new_file_entry, False, False, 0)
 
@@ -292,6 +326,12 @@ class PanelSelector(Gtk.Window):
         self.show_all()
 
         self.connect("show", self.refresh)
+
+    def show_common_settings(self, btn):
+        if self.common_settings_window:
+            self.common_settings_window.destroy()
+
+        self.common_settings_window = build_common_settings_window()
 
     def refresh(self, *args, reload=True):
         if reload:

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -366,7 +366,7 @@ class PanelSelector(Gtk.Window):
         inner_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         hbox.pack_start(inner_hbox, True, True, 12)
 
-        btn = Gtk.Button.new_with_label("Settings")
+        btn = Gtk.Button.new_with_label("Common")
         btn.set_tooltip_text("Common nwg-panel settings")
         btn.connect("clicked", self.show_common_settings)
         inner_hbox.pack_start(btn, False, False, 3)

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -292,8 +292,9 @@ def close_common_settings(btn, window):
 
 def apply_common_settings(btn, window):
     save_json(common_settings, cs_file)
-    print(restart_cmd)
+    print("Saving common settings: {}".format(common_settings))
     subprocess.Popen(restart_cmd, shell=True)
+    print("Restarting: {}".format(restart_cmd))
     window.close()
 
 

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -270,9 +270,11 @@ def build_common_settings_window():
 
     btn = Gtk.Button.new_with_label("Apply")
     btn.connect("clicked", apply_common_settings, win)
+    btn.set_tooltip_text("Apply changes, restart nwg-panel")
     hbox.pack_end(btn, False, False, 6)
 
     btn = Gtk.Button.new_with_label("Close")
+    btn.set_tooltip_text("Close window w/o applying changes")
     btn.connect("clicked", close_common_settings, win)
     hbox.pack_end(btn, False, False, 6)
 

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -26,6 +26,7 @@ data_home = os.getenv('XDG_DATA_HOME') if os.getenv('XDG_DATA_HOME') else os.pat
 cs_file = os.path.join(config_dir, "common-settings.json")
 if not os.path.isfile(cs_file):
     common_settings = {
+        "restart-on-display": True,
         "restart-delay": 500
     }
     save_json(common_settings, cs_file)
@@ -236,7 +237,8 @@ def handle_keyboard(window, event):
 
 def build_common_settings_window():
     global common_settings
-    check_key(common_settings, "restart-delay", 0)
+    check_key(common_settings, "restart-on-display", True)
+    check_key(common_settings, "restart-delay", 500)
 
     win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     win.set_modal(True)
@@ -256,16 +258,21 @@ def build_common_settings_window():
     grid.set_row_spacing(6)
     grid.set_property("margin", 12)
 
+    cb = Gtk.CheckButton.new_with_label("Restart on display connected")
+    cb.set_active(common_settings["restart-on-display"])
+    cb.connect("toggled", on_restart_check_button)
+    grid.attach(cb, 0, 0, 3, 1)
+
     lbl = Gtk.Label.new("Restart delay [ms]:")
     lbl.set_property("halign", Gtk.Align.END)
-    grid.attach(lbl, 0, 0, 1, 1)
+    grid.attach(lbl, 0, 1, 1, 1)
 
     sb = Gtk.SpinButton.new_with_range(0, 30000, 100)
     sb.set_value(common_settings["restart-delay"])
     sb.connect("value-changed", on_restart_delay_changed)
     sb.set_tooltip_text("If, after turning a display off and back on, panels don't appear on it, it may mean\n"
                         "the display responds too slowly (e.g. if turned via HDMI). Try increasing this value.")
-    grid.attach(sb, 1, 0, 1, 1)
+    grid.attach(sb, 1, 1, 1, 1)
 
     hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
     vbox.pack_start(hbox, False, False, 6)
@@ -288,6 +295,11 @@ def build_common_settings_window():
 def on_restart_delay_changed(sb):
     global common_settings
     common_settings["restart-delay"] = int(sb.get_value())
+
+
+def on_restart_check_button(cb):
+    global common_settings
+    common_settings["restart-on-display"] = cb.get_active()
 
 
 def close_common_settings(btn, window):

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -262,7 +262,7 @@ def build_common_settings_window():
     sb.connect("changed", on_restart_delay_changed)
     sb.set_tooltip_text("If, after turning a display off and back on, panels don't appear on it, it may mean\n"
                         "the display responds too slowly (e.g. if turned via HDMI). Try adding some delay.\n"
-                        "Starting from 500 ms is a good idea.")
+                        "Starting from 500 ms may be a good idea.")
     grid.attach(sb, 1, 0, 1, 1)
 
     hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -26,6 +26,7 @@ data_home = os.getenv('XDG_DATA_HOME') if os.getenv('XDG_DATA_HOME') else os.pat
 cs_file = os.path.join(config_dir, "common-settings.json")
 if not os.path.isfile(cs_file):
     common_settings = {
+        "restart-on-displays": True,
         "restart-delay": 0
     }
     save_json(common_settings, cs_file)
@@ -235,6 +236,10 @@ def handle_keyboard(window, event):
 
 
 def build_common_settings_window():
+    global common_settings
+    check_key(common_settings, "restart-on-displays", True)
+    check_key(common_settings, "restart-delay", 0)
+
     win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     win.set_modal(True)
 
@@ -253,9 +258,14 @@ def build_common_settings_window():
     grid.set_row_spacing(6)
     grid.set_property("margin", 12)
 
+    cb = Gtk.CheckButton.new_with_label("Restart on output number changed")
+    cb.set_active(common_settings["restart-on-displays"])
+    cb.connect("toggled", on_restart_checkbutton)
+    grid.attach(cb, 0, 0, 3, 1)
+
     lbl = Gtk.Label.new("Restart delay [ms]:")
     lbl.set_property("halign", Gtk.Align.END)
-    grid.attach(lbl, 0, 0, 1, 1)
+    grid.attach(lbl, 0, 1, 1, 1)
 
     sb = Gtk.SpinButton.new_with_range(0, 10000, 100)
     sb.set_value(common_settings["restart-delay"])
@@ -263,7 +273,7 @@ def build_common_settings_window():
     sb.set_tooltip_text("If, after turning a display off and back on, panels don't appear on it, it may mean\n"
                         "the display responds too slowly (e.g. if turned via HDMI). Try adding some delay.\n"
                         "Starting from 500 ms may be a good idea.")
-    grid.attach(sb, 1, 0, 1, 1)
+    grid.attach(sb, 1, 1, 1, 1)
 
     hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
     vbox.pack_start(hbox, False, False, 6)
@@ -281,6 +291,11 @@ def build_common_settings_window():
     win.show_all()
 
     return win
+
+
+def on_restart_checkbutton(cb):
+    global common_settings
+    common_settings["restart-on-displays"] = cb.get_active()
 
 
 def on_restart_delay_changed(sb):

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -272,7 +272,7 @@ def build_common_settings_window():
     sb.connect("value-changed", on_restart_delay_changed)
     sb.set_tooltip_text("If, after turning a display off and back on, panels don't appear on it, it may mean\n"
                         "the display responds too slowly (e.g. if turned via HDMI). Try adding some delay.\n"
-                        "Starting from 500 ms may be a good idea.")
+                        "Starting from 2000 ms may be a good idea.")
     grid.attach(sb, 1, 1, 1, 1)
 
     hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -267,7 +267,7 @@ def build_common_settings_window():
     lbl.set_property("halign", Gtk.Align.END)
     grid.attach(lbl, 0, 1, 1, 1)
 
-    sb = Gtk.SpinButton.new_with_range(0, 10000, 100)
+    sb = Gtk.SpinButton.new_with_range(0, 30000, 100)
     sb.set_value(common_settings["restart-delay"])
     sb.connect("changed", on_restart_delay_changed)
     sb.set_tooltip_text("If, after turning a display off and back on, panels don't appear on it, it may mean\n"

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -26,8 +26,7 @@ data_home = os.getenv('XDG_DATA_HOME') if os.getenv('XDG_DATA_HOME') else os.pat
 cs_file = os.path.join(config_dir, "common-settings.json")
 if not os.path.isfile(cs_file):
     common_settings = {
-        "restart-on-displays": True,
-        "restart-delay": 0
+        "restart-delay": 500
     }
     save_json(common_settings, cs_file)
 else:
@@ -237,7 +236,6 @@ def handle_keyboard(window, event):
 
 def build_common_settings_window():
     global common_settings
-    check_key(common_settings, "restart-on-displays", True)
     check_key(common_settings, "restart-delay", 0)
 
     win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
@@ -258,22 +256,16 @@ def build_common_settings_window():
     grid.set_row_spacing(6)
     grid.set_property("margin", 12)
 
-    cb = Gtk.CheckButton.new_with_label("Restart on output number changed")
-    cb.set_active(common_settings["restart-on-displays"])
-    cb.connect("toggled", on_restart_checkbutton)
-    grid.attach(cb, 0, 0, 3, 1)
-
     lbl = Gtk.Label.new("Restart delay [ms]:")
     lbl.set_property("halign", Gtk.Align.END)
-    grid.attach(lbl, 0, 1, 1, 1)
+    grid.attach(lbl, 0, 0, 1, 1)
 
     sb = Gtk.SpinButton.new_with_range(0, 30000, 100)
     sb.set_value(common_settings["restart-delay"])
     sb.connect("value-changed", on_restart_delay_changed)
     sb.set_tooltip_text("If, after turning a display off and back on, panels don't appear on it, it may mean\n"
-                        "the display responds too slowly (e.g. if turned via HDMI). Try adding some delay.\n"
-                        "Starting from 2000 ms may be a good idea.")
-    grid.attach(sb, 1, 1, 1, 1)
+                        "the display responds too slowly (e.g. if turned via HDMI). Try increasing this value.")
+    grid.attach(sb, 1, 0, 1, 1)
 
     hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
     vbox.pack_start(hbox, False, False, 6)
@@ -291,11 +283,6 @@ def build_common_settings_window():
     win.show_all()
 
     return win
-
-
-def on_restart_checkbutton(cb):
-    global common_settings
-    common_settings["restart-on-displays"] = cb.get_active()
 
 
 def on_restart_delay_changed(sb):

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -121,7 +121,8 @@ def check_tree():
                 else:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))
-                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                    # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                    restart()
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -113,7 +113,7 @@ def check_tree():
     if tree:
         # Do if tree changed
         if tree.ipc_data != common.ipc_data:
-            if len(common.i3.get_outputs()) != common.outputs_num:
+            if common_settings["restart-on-displays"] and len(common.i3.get_outputs()) != common.outputs_num:
                 print("Number of outputs changed")
                 Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
@@ -345,6 +345,7 @@ def main():
     cs_file = os.path.join(common.config_dir, "common-settings.json")
     if not os.path.isfile(cs_file):
         common_settings = {
+            "restart-on-displays": True,
             "restart-delay": 0
         }
         save_json(common_settings, cs_file)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -123,7 +123,7 @@ def check_tree():
                 else:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))
-                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
+                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
                 common.outputs_num = num
 

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,8 +116,12 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
+                    print("Number of outputs decreased {}, restarting".format(num))
+                    restart()
+                else:
+                    print("Number of outputs increased ({}); restart in {} ms."
+                          .format(num, common_settings["restart-delay"]))
                     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
-                    # restart()
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -115,12 +115,8 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             num = num_active_outputs()
             if num != common.outputs_num:
-                if num < common.outputs_num:
-                    print("Output(s) turned off")
-                    restart()
-                else:
-                    print("Output(s) turned on")
-                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                print("Number of outputs changed", num)
+                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -114,7 +114,7 @@ def check_tree():
         # Do if tree changed
         if tree.ipc_data != common.ipc_data:
             num = num_active_outputs()
-            if common_settings["restart-on-displays"] and num != common.outputs_num:
+            if num != common.outputs_num:
                 print("Number of active outputs changed: {}".format(num))
                 Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
@@ -346,8 +346,7 @@ def main():
     cs_file = os.path.join(common.config_dir, "common-settings.json")
     if not os.path.isfile(cs_file):
         common_settings = {
-            "restart-on-displays": True,
-            "restart-delay": 0
+            "restart-delay": 500
         }
         save_json(common_settings, cs_file)
     else:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,7 +116,7 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    # print("Number of outputs decreased {}, restarting".format(num))
+                    print("Number of outputs decreased {}, restarting".format(num))
                     # restart()
                     # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
                     pass
@@ -124,6 +124,8 @@ def check_tree():
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))
                     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
+
+                common.outputs_num = num
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -117,7 +117,8 @@ def check_tree():
             if num != common.outputs_num:
                 if num < common.outputs_num:
                     print("Number of outputs decreased {}, restarting".format(num))
-                    restart()
+                    # restart()
+                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
                 else:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,8 +116,9 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    print("Number of outputs decreased {}, restarting".format(num))
-                    restart()
+                    # print("Number of outputs decreased {}, restarting".format(num))
+                    # restart()
+                    pass
                 else:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,13 +116,8 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    print("Number of outputs decreased {}, restarting".format(num))
-                    restart()
-                else:
-                    print("Number of outputs increased ({}); restart in {} ms."
-                          .format(num, common_settings["restart-delay"]))
-                    # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
-                    restart()
+                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                    # restart()
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -121,7 +121,7 @@ def check_tree():
                 else:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))
-                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,13 +116,14 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    print("Number of outputs decreased {}, restarting".format(num))
                     restart()
-                else:
-                    print("Number of outputs increased ({}); restart in {} ms."
-                          .format(num, common_settings["restart-delay"]))
-                    # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
-                    restart()
+                #     print("Number of outputs decreased {}, restarting".format(num))
+                #     restart()
+                # else:
+                #     print("Number of outputs increased ({}); restart in {} ms."
+                #           .format(num, common_settings["restart-delay"]))
+                #     # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                #     restart()
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -113,8 +113,9 @@ def check_tree():
     if tree:
         # Do if tree changed
         if tree.ipc_data != common.ipc_data:
-            if common_settings["restart-on-displays"] and len(common.i3.get_outputs()) != common.outputs_num:
-                print("Number of outputs changed")
+            num = num_active_outputs()
+            if common_settings["restart-on-displays"] and num != common.outputs_num:
+                print("Number of active outputs changed: {}".format(num))
                 Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:
@@ -674,10 +675,11 @@ def main():
             window.show_all()
 
     if sway:
-        common.outputs_num = len(common.i3.get_outputs())
+        common.outputs_num = num_active_outputs()
     else:
         common.outputs = list_outputs(sway=sway, tree=tree, silent=True)
         common.outputs_num = len(common.outputs)
+
     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 200, check_tree)
 
     if tray_available and len(common.tray_list) > 0:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -113,19 +113,14 @@ def check_tree():
     if tree:
         # Do if tree changed
         if tree.ipc_data != common.ipc_data:
-            num = num_active_outputs(tree)
-            if num != common.outputs_num:
-                if num < common.outputs_num:
-                    print("Number of outputs decreased {}, restarting".format(num))
-                    # restart()
-                    # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
-                    pass
-                else:
+            if common_settings["restart-on-display"]:
+                num = num_active_outputs(tree)
+                if num > common.outputs_num:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))
                     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
-                common.outputs_num = num
+                    common.outputs_num = num
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,7 +116,10 @@ def check_tree():
             num = num_active_outputs()
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    print("Number of outputs changed:", num)
+                    print("Number of outputs decreased:", num)
+                    restart()
+                else:
+                    print("Number of outputs increased:", num)
                     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -104,6 +104,7 @@ def rt_sig_handler(sig, frame):
 
 
 def restart():
+    time.sleep(5)
     subprocess.Popen(restart_cmd, shell=True)
 
 

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,10 +116,11 @@ def check_tree():
             num = num_active_outputs()
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    print("Number of outputs decreased:", num)
+                    print("Number of outputs decreased {}, restarting".format(num))
                     restart()
                 else:
-                    print("Number of outputs increased:", num)
+                    print("Number of outputs increased ({}); restart in {} ms.".format(num,
+                                                                                      common_settings["restart-delay"]))
                     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:
@@ -378,7 +379,7 @@ def main():
         except Exception as exc:
             eprint("{} subscription error: {}".format(sig, exc))
 
-    for sig in range(signal.SIGRTMIN, signal.SIGRTMAX+1):
+    for sig in range(signal.SIGRTMIN, signal.SIGRTMAX + 1):
         try:
             signal.signal(sig, rt_sig_handler)
         except Exception as exc:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -114,8 +114,7 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             if len(common.i3.get_outputs()) != common.outputs_num:
                 print("Number of outputs changed")
-                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 5000, check_tree)
-                restart()
+                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 5000, restart)
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -79,6 +79,7 @@ if sway:
     from nwg_panel.modules.sway_taskbar import SwayTaskbar
     from nwg_panel.modules.sway_workspaces import SwayWorkspaces
 
+common_settings = {}
 restart_cmd = ""
 sig_dwl = 0
 
@@ -114,7 +115,7 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             if len(common.i3.get_outputs()) != common.outputs_num:
                 print("Number of outputs changed")
-                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 5000, restart)
+                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:
                 item.refresh(tree)
@@ -339,6 +340,19 @@ def main():
     save_string(str(own_pid), pid_file)
 
     common.config_dir = get_config_dir()
+
+    global common_settings
+    cs_file = os.path.join(common.config_dir, "common-settings.json")
+    if not os.path.isfile(cs_file):
+        common_settings = {
+            "restart-delay": 0
+        }
+        save_json(common_settings, cs_file)
+    else:
+        common_settings = load_json(cs_file)
+
+    print("Common settings", common_settings)
+
     cache_dir = get_cache_dir()
     if cache_dir:
         common.dwl_data_file = os.path.join(cache_dir, "nwg-dwl-data")

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -113,14 +113,14 @@ def check_tree():
     if tree:
         # Do if tree changed
         if tree.ipc_data != common.ipc_data:
-            num = num_active_outputs()
+            num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
                     print("Number of outputs decreased {}, restarting".format(num))
                     restart()
                 else:
-                    print("Number of outputs increased ({}); restart in {} ms.".format(num,
-                                                                                      common_settings["restart-delay"]))
+                    print("Number of outputs increased ({}); restart in {} ms."
+                          .format(num, common_settings["restart-delay"]))
                     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:
@@ -679,7 +679,7 @@ def main():
             window.show_all()
 
     if sway:
-        common.outputs_num = num_active_outputs()
+        common.outputs_num = num_active_outputs(common.i3.get_tree())
     else:
         common.outputs = list_outputs(sway=sway, tree=tree, silent=True)
         common.outputs_num = len(common.outputs)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,9 +116,10 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    print("Number of outputs decreased {}, restarting".format(num))
-                    restart()
+                    # print("Number of outputs decreased {}, restarting".format(num))
+                    # restart()
                     # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
+                    pass
                 else:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,10 +116,7 @@ def check_tree():
             num = num_active_outputs()
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    print("Number of outputs decreased:", num)
-                    restart()
-                else:
-                    print("Number of outputs increased", num)
+                    print("Number of outputs changed:", num)
                     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,13 +116,13 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    #     restart()
-                    #     print("Number of outputs decreased {}, restarting".format(num))
-                    #     restart()
-                    # else:
-                    #     print("Number of outputs increased ({}); restart in {} ms."
-                    #           .format(num, common_settings["restart-delay"]))
-                    #     # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                    restart()
+                    print("Number of outputs decreased {}, restarting".format(num))
+                    restart()
+                else:
+                    print("Number of outputs increased ({}); restart in {} ms."
+                          .format(num, common_settings["restart-delay"]))
+                    # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
                     restart()
 
             for item in common.taskbars_list:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -115,14 +115,15 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             num = num_active_outputs(tree)
             if num != common.outputs_num:
-                if num < common.outputs_num:
-                    print("Number of outputs decreased {}, restarting".format(num))
-                    # restart()
-                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
-                else:
-                    print("Number of outputs increased ({}); restart in {} ms."
-                          .format(num, common_settings["restart-delay"]))
-                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
+                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
+                # if num < common.outputs_num:
+                #     print("Number of outputs decreased {}, restarting".format(num))
+                #     # restart()
+                #     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
+                # else:
+                #     print("Number of outputs increased ({}); restart in {} ms."
+                #           .format(num, common_settings["restart-delay"]))
+                #     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -114,7 +114,7 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             if len(common.i3.get_outputs()) != common.outputs_num:
                 print("Number of outputs changed")
-                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 2000, check_tree)
+                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 5000, check_tree)
                 restart()
 
             for item in common.taskbars_list:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -115,8 +115,12 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             num = num_active_outputs()
             if num != common.outputs_num:
-                print("Number of active outputs changed: {}".format(num))
-                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                if num < common.outputs_num:
+                    print("Output(s) turned off")
+                    restart()
+                else:
+                    print("Output(s) turned on")
+                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -355,6 +355,7 @@ def main():
     cs_file = os.path.join(common.config_dir, "common-settings.json")
     if not os.path.isfile(cs_file):
         common_settings = {
+            "restart-on-display": True,
             "restart-delay": 500
         }
         save_json(common_settings, cs_file)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -115,15 +115,14 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             num = num_active_outputs(tree)
             if num != common.outputs_num:
-                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
-                # if num < common.outputs_num:
-                #     print("Number of outputs decreased {}, restarting".format(num))
-                #     # restart()
-                #     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
-                # else:
-                #     print("Number of outputs increased ({}); restart in {} ms."
-                #           .format(num, common_settings["restart-delay"]))
-                #     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
+                if num < common.outputs_num:
+                    print("Number of outputs decreased {}, restarting".format(num))
+                    restart()
+                    # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
+                else:
+                    print("Number of outputs increased ({}); restart in {} ms."
+                          .format(num, common_settings["restart-delay"]))
+                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 0, restart)
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -115,12 +115,13 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             if common_settings["restart-on-display"]:
                 num = num_active_outputs(tree)
+
                 if num > common.outputs_num:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))
                     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
-                    common.outputs_num = num
+                common.outputs_num = num
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,13 +116,13 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    restart()
-                    print("Number of outputs decreased {}, restarting".format(num))
-                    restart()
-                else:
-                    print("Number of outputs increased ({}); restart in {} ms."
-                          .format(num, common_settings["restart-delay"]))
-                    # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                    #     restart()
+                    #     print("Number of outputs decreased {}, restarting".format(num))
+                    #     restart()
+                    # else:
+                    #     print("Number of outputs increased ({}); restart in {} ms."
+                    #           .format(num, common_settings["restart-delay"]))
+                    #     # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
                     restart()
 
             for item in common.taskbars_list:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -104,7 +104,6 @@ def rt_sig_handler(sig, frame):
 
 
 def restart():
-    time.sleep(5)
     subprocess.Popen(restart_cmd, shell=True)
 
 
@@ -115,6 +114,7 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             if len(common.i3.get_outputs()) != common.outputs_num:
                 print("Number of outputs changed")
+                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 2000, check_tree)
                 restart()
 
             for item in common.taskbars_list:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,9 +116,8 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    # print("Number of outputs decreased {}, restarting".format(num))
-                    # restart()
-                    pass
+                    print("Number of outputs decreased {}, restarting".format(num))
+                    restart()
                 else:
                     print("Number of outputs increased ({}); restart in {} ms."
                           .format(num, common_settings["restart-delay"]))

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -116,7 +116,6 @@ def check_tree():
             num = num_active_outputs(tree)
             if num != common.outputs_num:
                 if num < common.outputs_num:
-                    restart()
                     print("Number of outputs decreased {}, restarting".format(num))
                     restart()
                 else:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -115,8 +115,12 @@ def check_tree():
         if tree.ipc_data != common.ipc_data:
             num = num_active_outputs()
             if num != common.outputs_num:
-                print("Number of outputs changed", num)
-                Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                if num < common.outputs_num:
+                    print("Number of outputs decreased:", num)
+                    restart()
+                else:
+                    print("Number of outputs increased", num)
+                    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -117,13 +117,13 @@ def check_tree():
             if num != common.outputs_num:
                 if num < common.outputs_num:
                     restart()
-                #     print("Number of outputs decreased {}, restarting".format(num))
-                #     restart()
-                # else:
-                #     print("Number of outputs increased ({}); restart in {} ms."
-                #           .format(num, common_settings["restart-delay"]))
-                #     # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
-                #     restart()
+                    print("Number of outputs decreased {}, restarting".format(num))
+                    restart()
+                else:
+                    print("Number of outputs increased ({}); restart in {} ms."
+                          .format(num, common_settings["restart-delay"]))
+                    # Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, common_settings["restart-delay"], restart)
+                    restart()
 
             for item in common.taskbars_list:
                 item.refresh(tree)

--- a/nwg_panel/modules/executor.py
+++ b/nwg_panel/modules/executor.py
@@ -19,7 +19,6 @@ class Executor(Gtk.EventBox):
     def __init__(self, settings, icons_path, executor_name):
         self.name = executor_name
         self.settings = settings
-        print("executor name:", self.name)
         self.icons_path = icons_path
         Gtk.EventBox.__init__(self)
         self.box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -258,7 +258,6 @@ def num_active_outputs(tree):
     for item in tree:
         if item.type == "output" and not item.name.startswith("__"):
             a += 1
-    print("num_active_outputs", a)
     return a
 
 

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -255,9 +255,11 @@ def load_autotiling():
 
 def num_active_outputs():
     a = 0
-    for o in nwg_panel.common.i3.get_outputs():
-        if o.active and o.dpms:
+    tree = nwg_panel.common.i3.get_tree()
+    for item in tree:
+        if item.type == "output" and not item.name.startswith("__"):
             a += 1
+    print("num_active_outputs", a)
     return a
 
 

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -253,6 +253,14 @@ def load_autotiling():
     return autotiling
 
 
+def num_active_outputs():
+    a = 0
+    for o in nwg_panel.common.i3.get_outputs():
+        if o.active:
+            a += 1
+    return a
+
+
 def list_outputs(sway=False, tree=None, silent=False):
     """
     Get output names and geometry from i3 tree, assign to Gdk.Display monitors.

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -253,9 +253,8 @@ def load_autotiling():
     return autotiling
 
 
-def num_active_outputs():
+def num_active_outputs(tree):
     a = 0
-    tree = nwg_panel.common.i3.get_tree()
     for item in tree:
         if item.type == "output" and not item.name.startswith("__"):
             a += 1

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -678,7 +678,8 @@ def list_configs(config_dir):
     # allow to store json files other than panel config files in the config directory
     # (prevents from crash w/ nwg-drawer>=0.1.7 and future nwg-menu versions)
     exclusions = [os.path.join(config_dir, "preferred-apps.json"),
-                  os.path.join(config_dir, "calendar.json")]
+                  os.path.join(config_dir, "calendar.json"),
+                  os.path.join(config_dir, "common-settings.json")]
     entries = os.listdir(config_dir)
     entries.sort()
     for entry in entries:

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -256,7 +256,7 @@ def load_autotiling():
 def num_active_outputs():
     a = 0
     for o in nwg_panel.common.i3.get_outputs():
-        if o.active:
+        if o.active and o.dpms:
             a += 1
     return a
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.7.15',
+    version='0.7.16',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Changes the way the panel behaves when the number of active displays changes. A new window for "Common settings" has been added. They are stored in `/.config/nwg-panel/common-settings.json`. Default values:

```json
{
  "restart-on-display": true,
  "restart-delay": 500
}
```

![image](https://user-images.githubusercontent.com/20579136/211697327-d9251ad9-051f-4b4c-9b7f-daa6da1a6ac1.png)

From now on, nothing's going to happen if one of displays disappears. If the "Restart on display connected" box is marked, the panel will be restarted after a "Restart delay [ms]" delay, when a display gets connected/activated.

If some display, e.g. attached by HDMI, needs more time to get ready, you may increase the default restart delay. Depending on your hardware, you may need no delay at all: set 0 if so.

This may (or may not) resolve #173.