### PR TITLE
Remove stray backslashes from upower command

### DIFF
--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -526,7 +526,7 @@ def get_battery():
 
     if not success and nwg_panel.common.commands["upower"]:
         lines = subprocess.check_output(
-            "upower -i $(upower -e | grep devices/battery) | grep --color=never -E 'state|to\ full|to\ empty|percentage'",
+            "upower -i $(upower -e | grep devices/battery) | grep --color=never -E 'state|to[[:space:]]full|to[[:space:]]empty|percentage'",
             shell=True).decode("utf-8").strip().splitlines()
         for line in lines:
             if "state:" in line:


### PR DESCRIPTION
I've been seeing this error constantly in my systemd log: `grep: warning: stray \ before white space`. I tracked it down to nwg-panel and this command:

    grep --color=never -E 'state|to\ full|to\ empty|percentage'

Matching the spaces with `[[:space:]]` instead cleans up the warning. I think you could just use literal, un-backslashed spaces here (it works for me, at least), but I decided to be extra clear.

Thanks for your work on this project, it's been really nice to have so many tools put together for a sway environment.