### PR TITLE
Process browser & battery low notification

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,4 +3,5 @@
 python3 setup.py install --optimize=1
 cp nwg-panel.svg /usr/share/pixmaps/
 cp nwg-shell.svg /usr/share/pixmaps/
+cp nwg-processes.svg /usr/share/pixmaps/
 cp nwg-panel-config.desktop /usr/share/applications/

--- a/install.sh
+++ b/install.sh
@@ -5,3 +5,4 @@ cp nwg-panel.svg /usr/share/pixmaps/
 cp nwg-shell.svg /usr/share/pixmaps/
 cp nwg-processes.svg /usr/share/pixmaps/
 cp nwg-panel-config.desktop /usr/share/applications/
+cp nwg-processes.desktop /usr/share/applications/

--- a/nwg-processes.desktop
+++ b/nwg-processes.desktop
@@ -1,0 +1,15 @@
+[Desktop Entry]
+Type=Application
+
+Name=nwg-processes
+
+GenericName=nwg-shell process manager
+GenericName[pl]=Menadżer zadań nwg-shell
+
+Comment=System process browser
+Comment[pl]=Przeglądarka procesów systemowych
+
+Exec=nwg-processes
+Icon=nwg-processes
+Terminal=false
+Categories=System;Utility;

--- a/nwg-processes.svg
+++ b/nwg-processes.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="nwg-processes.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.795939"
+     inkscape:cx="15.901955"
+     inkscape:cy="10.374655"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1918"
+     inkscape:window-height="1018"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0"
+     width="16px"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true">
+    <sodipodi:guide
+       position="-0.30184528,2.3887234"
+       orientation="0,-1"
+       id="guide1991"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0.81783828,4.1614617"
+       orientation="-1,0"
+       id="guide1993"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="3.4007901,3.7570887"
+       orientation="1,0"
+       id="guide3550"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00aad4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.41669;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 3.7168926,281.81044 -1.0109451,0.69373 -1.1499969,-1.24444 -1.111821,0.94199 0.001605,0.93295 h 3.2680792 z"
+       id="path3451"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       id="rect815"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#00aad4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.329802;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 0.26458334,280.33123 v 0.16487 2.81236 H 1.727185 v 0.42506 H 1.0415017 v 0.31167 h 2.1503298 v -0.31167 H 2.5062623 v -0.42506 H 3.96875 v -2.97723 z m 0.32983243,0.32973 H 3.6389178 v 2.31777 H 0.59441577 Z" />
+  </g>
+</svg>

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -2870,7 +2870,8 @@ class EditorWrapper(object):
                 "net",
                 "brightness",
                 "volume",
-                "battery"
+                "battery",
+                "processes"
             ],
             "commands": {
             },
@@ -2954,6 +2955,9 @@ class EditorWrapper(object):
 
         self.ctrl_comp_battery = builder.get_object("ctrl-comp-battery")
         self.ctrl_comp_battery.set_active("battery" in settings["components"])
+
+        self.ctrl_comp_processes = builder.get_object("ctrl-comp-processes")
+        self.ctrl_comp_processes.set_active("processes" in settings["components"])
 
         self.ctrl_cdm_net = builder.get_object("ctrl-cmd-net")
         check_key(settings["commands"], "net", "")
@@ -3068,6 +3072,13 @@ class EditorWrapper(object):
         else:
             if "battery" in settings["components"]:
                 settings["components"].remove("battery")
+
+        if self.ctrl_comp_processes.get_active():
+            if "processes" not in settings["components"]:
+                settings["components"].append("processes")
+        else:
+            if "processes" in settings["components"]:
+                settings["components"].remove("processes")
 
         settings["commands"]["net"] = self.ctrl_cdm_net.get_text()
         settings["net-interface"] = self.ctrl_net_name.get_text()

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -239,6 +239,7 @@ def build_common_settings_window():
     global common_settings
     check_key(common_settings, "restart-on-display", True)
     check_key(common_settings, "restart-delay", 500)
+    check_key(common_settings, "processes-interval-ms", 2000)
 
     win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     win.set_modal(True)
@@ -269,10 +270,21 @@ def build_common_settings_window():
 
     sb = Gtk.SpinButton.new_with_range(0, 30000, 100)
     sb.set_value(common_settings["restart-delay"])
-    sb.connect("value-changed", on_restart_delay_changed)
+    sb.connect("value-changed", set_int_from_spin_button, "restart-delay")
     sb.set_tooltip_text("If, after turning a display off and back on, panels don't appear on it, it may mean\n"
                         "the display responds too slowly (e.g. if turned via HDMI). Try increasing this value.")
     grid.attach(sb, 1, 1, 1, 1)
+
+    lbl = Gtk.Label.new("Processes polling rate [ms]:")
+    lbl.set_property("halign", Gtk.Align.END)
+    grid.attach(lbl, 0, 2, 1, 1)
+
+    sb = Gtk.SpinButton.new_with_range(0, 30000, 100)
+    sb.set_value(common_settings["processes-interval-ms"])
+    sb.connect("value-changed", set_int_from_spin_button, "processes-interval-ms")
+    sb.set_tooltip_text("Interval for checking data on system processes by the nwg-processes tool.\n"
+                        "Default: 2000 ms. Set higher values for slower machines. Set 0 to stop refreshing.")
+    grid.attach(sb, 1, 2, 1, 1)
 
     hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
     vbox.pack_start(hbox, False, False, 6)
@@ -292,9 +304,9 @@ def build_common_settings_window():
     return win
 
 
-def on_restart_delay_changed(sb):
+def set_int_from_spin_button(sb, config_key):
     global common_settings
-    common_settings["restart-delay"] = int(sb.get_value())
+    common_settings[config_key] = int(sb.get_value())
 
 
 def on_restart_check_button(cb):

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -39,7 +39,6 @@ args = load_string(args_file) if os.path.isfile(args_file) else ""
 restart_cmd = "nwg-panel {}".format(args)
 print("Restart command: ", restart_cmd)
 
-
 configs = {}
 editor = None
 selector_window = None
@@ -76,6 +75,8 @@ SKELETON_PANEL: dict = {
         "root-css-name": "controls-overview",
         "css-name": "controls-window",
         "net-interface": "",
+        "battery-low-level": 20,
+        "battery-low-interval": 3,
         "custom-items": [{"name": "Panel settings", "icon": "nwg-panel", "cmd": "nwg-panel-config"}],
         "menu": {"name": "unnamed", "icon": "", "items": []}
     },
@@ -2902,6 +2903,8 @@ class EditorWrapper(object):
             "root-css-name": "controls-overview",
             "css-name": "controls-window",
             "net-interface": "",
+            "battery-low-level": 20,
+            "battery-low-interval": 3,
             "angle": 0.0,
             "custom-items": [
                 {
@@ -2967,6 +2970,18 @@ class EditorWrapper(object):
 
         self.ctrl_comp_battery = builder.get_object("ctrl-comp-battery")
         self.ctrl_comp_battery.set_active("battery" in settings["components"])
+
+        self.ctrl_comp_battery_low_level = builder.get_object("ctrl-battery-low-level")
+        self.ctrl_comp_battery_low_level.set_numeric(True)
+        adj = Gtk.Adjustment(value=0, lower=1, upper=100, step_increment=1, page_increment=10, page_size=1)
+        self.ctrl_comp_battery_low_level.configure(adj, 1, 0)
+        self.ctrl_comp_battery_low_level.set_value(settings["battery-low-level"])
+
+        self.ctrl_comp_battery_low_interval = builder.get_object("ctrl-battery-low-interval")
+        self.ctrl_comp_battery_low_interval.set_numeric(True)
+        adj = Gtk.Adjustment(value=0, lower=0, upper=61, step_increment=1, page_increment=10, page_size=1)
+        self.ctrl_comp_battery_low_interval.configure(adj, 1, 0)
+        self.ctrl_comp_battery_low_interval.set_value(settings["battery-low-interval"])
 
         self.ctrl_comp_processes = builder.get_object("ctrl-comp-processes")
         self.ctrl_comp_processes.set_active("processes" in settings["components"])
@@ -3098,6 +3113,9 @@ class EditorWrapper(object):
         settings["commands"]["battery"] = self.ctrl_cdm_battery.get_text()
         settings["root-css-name"] = self.ctrl_root_css_name.get_text()
         settings["css-name"] = self.ctrl_css_name.get_text()
+
+        settings["battery-low-level"] = int(self.ctrl_comp_battery_low_level.get_value())
+        settings["battery-low-interval"] = int(self.ctrl_comp_battery_low_interval.get_value())
 
         settings["window-width"] = int(self.ctrl_window_width.get_value())
         settings["window-margin-horizontal"] = int(self.ctrl_window_margin_horizontal.get_value())

--- a/nwg_panel/glade/config_controls.glade
+++ b/nwg_panel/glade/config_controls.glade
@@ -65,176 +65,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkEntry" id="ctrl-cmd-battery">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="placeholder-text" translatable="yes">on click command</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Depends on `python-psutil`.</property>
-            <property name="halign">start</property>
-            <property name="icon-name">help-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="ctrl-comp-battery">
-            <property name="label" translatable="yes">Battery</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="halign">start</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="ctrl-cmd-bluetooth">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="placeholder-text" translatable="yes">on click command</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Depends on `bluez-utils`.</property>
-            <property name="halign">start</property>
-            <property name="icon-name">help-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="ctrl-comp-bluetooth">
-            <property name="label" translatable="yes">Bluetooth</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="halign">start</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="ctrl-net-name">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">6</property>
-            <property name="placeholder-text" translatable="yes">name</property>
-          </object>
-          <packing>
-            <property name="left-attach">3</property>
-            <property name="top-attach">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="ctrl-cmd-net">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="placeholder-text" translatable="yes">on click command</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Network interface status;
-use `ifconfig` to check names,
-e.g. `enp6s0`or `wlo1`.
-Depends on `python-netifaces`.</property>
-            <property name="halign">start</property>
-            <property name="icon-name">help-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="ctrl-comp-net">
-            <property name="label" translatable="yes">Interface</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="halign">start</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Depends on the `pamixer` package.</property>
-            <property name="halign">start</property>
-            <property name="icon-name">help-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="ctrl-comp-volume">
-            <property name="label" translatable="yes">Volume</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="halign">start</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="ctrl-comp-brightness">
-            <property name="label" translatable="yes">Brightness</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="halign">start</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">1</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -267,20 +97,6 @@ Depends on `python-netifaces`.</property>
           <packing>
             <property name="left-attach">2</property>
             <property name="top-attach">8</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="output-switcher">
-            <property name="label" translatable="yes">output switcher</property>
-            <property name="name">pactl</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">2</property>
           </packing>
         </child>
         <child>
@@ -401,64 +217,6 @@ the horizontal, in degrees, measured counterclockwise</property>
           </packing>
         </child>
         <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Depends on `light` or `brightnessctl`.</property>
-            <property name="halign">start</property>
-            <property name="icon-name">help-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Backlight device path (for 'light')
-or name (for 'brightnessctl')
-or I2C bus number (for 'ddcutil').
-Use 'light -L' or 'brightnessctl -l'
-or 'ddcutil --help' to
-check available devices.
-LEAVE BLANK IF EVERYTHING WORKS</property>
-            <property name="halign">start</property>
-            <property name="icon-name">help-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">4</property>
-            <property name="top-attach">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="backlight-device">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="placeholder-text" translatable="yes">backlight device</property>
-          </object>
-          <packing>
-            <property name="left-attach">3</property>
-            <property name="top-attach">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="backlight-controller">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <items>
-              <item id="light" translatable="yes">light</item>
-              <item id="brightnessctl" translatable="yes">brightnessctl</item>
-              <item id="ddcutil" translatable="yes">ddcutil</item>
-            </items>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">1</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -533,10 +291,273 @@ values in the panel widget</property>
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkCheckButton" id="ctrl-comp-brightness">
+            <property name="label" translatable="yes">Brightness</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="halign">start</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">0</property>
+          </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Depends on `light` or `brightnessctl`.</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="backlight-controller">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <items>
+              <item id="light" translatable="yes">light</item>
+              <item id="brightnessctl" translatable="yes">brightnessctl</item>
+              <item id="ddcutil" translatable="yes">ddcutil</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="backlight-device">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="placeholder-text" translatable="yes">backlight device</property>
+          </object>
+          <packing>
+            <property name="left-attach">3</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Backlight device path (for 'light')
+or name (for 'brightnessctl')
+or I2C bus number (for 'ddcutil').
+Use 'light -L' or 'brightnessctl -l'
+or 'ddcutil --help' to
+check available devices.
+LEAVE BLANK IF EVERYTHING WORKS</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">4</property>
+            <property name="top-attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="ctrl-comp-volume">
+            <property name="label" translatable="yes">Volume</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="halign">start</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Depends on the `pamixer` package.</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="output-switcher">
+            <property name="label" translatable="yes">output switcher</property>
+            <property name="name">pactl</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="ctrl-comp-net">
+            <property name="label" translatable="yes">Interface</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="halign">start</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Network interface status;
+use `ifconfig` to check names,
+e.g. `enp6s0`or `wlo1`.
+Depends on `python-netifaces`.</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="ctrl-cmd-net">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="placeholder-text" translatable="yes">on click command</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="ctrl-net-name">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">6</property>
+            <property name="placeholder-text" translatable="yes">name</property>
+          </object>
+          <packing>
+            <property name="left-attach">3</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="ctrl-comp-bluetooth">
+            <property name="label" translatable="yes">Bluetooth</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="halign">start</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Depends on `bluez-utils`.</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="ctrl-cmd-bluetooth">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="placeholder-text" translatable="yes">on click command</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="ctrl-comp-battery">
+            <property name="label" translatable="yes">Battery</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="halign">start</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Depends on `python-psutil`.</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="ctrl-cmd-battery">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="placeholder-text" translatable="yes">on click command</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="ctrl-comp-processes">
+            <property name="label" translatable="yes">Processes</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="halign">start</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Determines if to display the task manager menu entry.</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">5</property>
+          </packing>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/glade/config_controls.glade
+++ b/nwg_panel/glade/config_controls.glade
@@ -8,7 +8,7 @@
     <property name="label-xalign">0.5</property>
     <property name="shadow-type">out</property>
     <child>
-      <!-- n-columns=5 n-rows=16 -->
+      <!-- n-columns=5 n-rows=18 -->
       <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -18,278 +18,6 @@
         <property name="margin-bottom">6</property>
         <property name="row-spacing">12</property>
         <property name="column-spacing">12</property>
-        <child>
-          <object class="GtkEntry" id="css-name">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">12</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">7</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">CSS name:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">7</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="root-css-name">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">12</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">6</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Root CSS name:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">6</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Window width:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">8</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkImage">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Controls window width in pixels; leave 0 for auto.</property>
-            <property name="halign">start</property>
-            <property name="icon-name">help-about</property>
-          </object>
-          <packing>
-            <property name="left-attach">3</property>
-            <property name="top-attach">8</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="window-width">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">8</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="interval">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">12</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Interval:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">12</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="icon-size">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">11</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Icon size:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">11</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Horizontal window margin:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">9</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="window-margin-horizontal">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">9</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="angle">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">the angle that the baseline of the label makes with 
-the horizontal, in degrees, measured counterclockwise</property>
-            <items>
-              <item id="0.0" translatable="yes">0°</item>
-              <item id="90.0" translatable="yes">90°</item>
-              <item id="270.0" translatable="yes">270°</item>
-            </items>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">13</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Angle:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">13</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Vertical window margin:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">10</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="window-margin-vertical">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">10</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <child>
-              <object class="GtkCheckButton" id="hover-opens">
-                <property name="label" translatable="yes">Widget hover opens</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="tooltip-text" translatable="yes">Determines if to open the Controls window
-on panel Controls widget pointed</property>
-                <property name="draw-indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="leave-closes">
-                <property name="label" translatable="yes">Window leave closes</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="tooltip-text" translatable="yes">Determines if to close the Controls
-window when left</property>
-                <property name="draw-indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="click-closes">
-                <property name="label" translatable="yes">Click outside closes</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="tooltip-text" translatable="yes">Determines if to close the Controls
-window on mouse click outside it</property>
-                <property name="draw-indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">15</property>
-            <property name="width">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="show-values">
-            <property name="label" translatable="yes">Values in widget</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="tooltip-text" translatable="yes">Determines if show the Controls
-values in the panel widget</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">14</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkCheckButton" id="ctrl-comp-brightness">
             <property name="label" translatable="yes">Brightness</property>
@@ -533,6 +261,300 @@ Depends on `python-netifaces`.</property>
           </packing>
         </child>
         <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Battery low notification at [%]:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="ctrl-battery-low-level">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkCheckButton" id="hover-opens">
+                <property name="label" translatable="yes">Widget hover opens</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Determines if to open the Controls window
+on panel Controls widget pointed</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="leave-closes">
+                <property name="label" translatable="yes">Window leave closes</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Determines if to close the Controls
+window when left</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="click-closes">
+                <property name="label" translatable="yes">Click outside closes</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Determines if to close the Controls
+window on mouse click outside it</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">17</property>
+            <property name="width">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="show-values">
+            <property name="label" translatable="yes">Values in widget</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="tooltip-text" translatable="yes">Determines if show the Controls
+values in the panel widget</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">16</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Angle:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">15</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="angle">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">the angle that the baseline of the label makes with 
+the horizontal, in degrees, measured counterclockwise</property>
+            <items>
+              <item id="0.0" translatable="yes">0°</item>
+              <item id="90.0" translatable="yes">90°</item>
+              <item id="270.0" translatable="yes">270°</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">15</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Interval:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">14</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="interval">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">14</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Icon size:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">13</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="icon-size">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">13</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Vertical window margin:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">12</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="window-margin-vertical">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">12</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Horizontal window margin:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">11</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="window-margin-horizontal">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">11</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Window width:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">10</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="window-width">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">10</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">CSS name:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">9</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="css-name">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">12</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">9</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Root CSS name:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="root-css-name">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">12</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Controls window width in pixels; leave 0 for auto.</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">3</property>
+            <property name="top-attach">10</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkCheckButton" id="ctrl-comp-processes">
             <property name="label" translatable="yes">Processes</property>
             <property name="visible">True</property>
@@ -543,7 +565,7 @@ Depends on `python-netifaces`.</property>
           </object>
           <packing>
             <property name="left-attach">0</property>
-            <property name="top-attach">5</property>
+            <property name="top-attach">7</property>
           </packing>
         </child>
         <child>
@@ -556,8 +578,57 @@ Depends on `python-netifaces`.</property>
           </object>
           <packing>
             <property name="left-attach">1</property>
-            <property name="top-attach">5</property>
+            <property name="top-attach">7</property>
           </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Low level check interval [min]</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="ctrl-battery-low-interval">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Set 0 to disable.</property>
+            <property name="halign">start</property>
+            <property name="icon-name">help-about</property>
+          </object>
+          <packing>
+            <property name="left-attach">3</property>
+            <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/icons_dark/nwg-processes.svg
+++ b/nwg_panel/icons_dark/nwg-processes.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="nwg-processes.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.95"
+     inkscape:cx="8.8172043"
+     inkscape:cy="10.394265"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="952"
+     inkscape:window-height="1010"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0"
+     width="16px"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true">
+    <sodipodi:guide
+       position="-0.30184528,2.3887234"
+       orientation="0,-1"
+       id="guide1991"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0.81783828,4.1614617"
+       orientation="-1,0"
+       id="guide1993"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="3.4007901,3.7570887"
+       orientation="1,0"
+       id="guide3550"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       id="path3451"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#444444;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.41669;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 0.26458334 280.33123 L 0.26458334 280.49608 L 0.26458334 283.30831 L 1.7270264 283.30831 L 1.7270264 283.73361 L 1.0412801 283.73361 L 1.0412801 284.04522 L 3.1920533 284.04522 L 3.1920533 283.73361 L 2.506307 283.73361 L 2.506307 283.30831 L 3.9687501 283.30831 L 3.9687501 280.33123 L 0.26458334 280.33123 z M 0.59427898 280.66093 L 3.6390544 280.66093 L 3.6390544 281.86396 L 2.705778 282.50423 L 1.5559774 281.25986 L 0.59427898 282.07428 L 0.59427898 280.66093 z " />
+  </g>
+</svg>

--- a/nwg_panel/icons_light/nwg-processes.svg
+++ b/nwg_panel/icons_light/nwg-processes.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="nwg-processes.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.95"
+     inkscape:cx="8.8172043"
+     inkscape:cy="10.394265"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="952"
+     inkscape:window-height="1010"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0"
+     width="16px"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true">
+    <sodipodi:guide
+       position="-0.30184528,2.3887234"
+       orientation="0,-1"
+       id="guide1991"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0.81783828,4.1614617"
+       orientation="-1,0"
+       id="guide1993"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,134,229)" />
+    <sodipodi:guide
+       position="3.4007901,3.7570887"
+       orientation="1,0"
+       id="guide3550"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-280.06665)">
+    <path
+       id="path3451"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#eeeeee;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.41669;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 0.26458334 280.33123 L 0.26458334 280.49608 L 0.26458334 283.30831 L 1.7270264 283.30831 L 1.7270264 283.73361 L 1.0412801 283.73361 L 1.0412801 284.04522 L 3.1920533 284.04522 L 3.1920533 283.73361 L 2.506307 283.73361 L 2.506307 283.30831 L 3.9687501 283.30831 L 3.9687501 280.33123 L 0.26458334 280.33123 z M 0.59427898 280.66093 L 3.6390544 280.66093 L 3.6390544 281.86396 L 2.705778 282.50423 L 1.5559774 281.25986 L 0.59427898 282.07428 L 0.59427898 280.66093 z " />
+  </g>
+</svg>

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -352,7 +352,9 @@ def main():
     if not os.path.isfile(cs_file):
         common_settings = {
             "restart-on-display": True,
-            "restart-delay": 500
+            "restart-delay": 500,
+            "processes-backgroud-only": True,
+            "processes-own-only": True
         }
         save_json(common_settings, cs_file)
     else:

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -550,8 +550,8 @@ class PopupWindow(Gtk.Window):
             inner_vbox.pack_start(inner_hbox, True, True, 6)
             v_box.pack_start(event_box, True, True, 0)
 
-            self.proc_icon_name = "view-refresh-symbolic"
-            self.proc_image = Gtk.Image.new_from_icon_name("nwg-processes", Gtk.IconSize.MENU)
+            self.proc_image = Gtk.Image()
+            update_image(self.proc_image, "nwg-processes", self.icon_size, self.icons_path)
 
             inner_hbox.pack_start(self.proc_image, False, False, 6)
 

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import threading
+import time
 import subprocess
 
 import gi
@@ -14,6 +15,8 @@ from nwg_panel.tools import check_key, get_brightness, set_brightness, get_volum
     get_interface, update_image, bt_info, eprint, list_sinks, toggle_mute
 
 from nwg_panel.common import commands
+
+bat_critical_last_check = 0
 
 
 class Controls(Gtk.EventBox):
@@ -32,9 +35,11 @@ class Controls(Gtk.EventBox):
         check_key(settings, "leave-closes", True)
         check_key(settings, "click-closes", False)
         check_key(settings, "root-css-name", "controls-overview")
-        check_key(settings, "components", ["net", "brightness", "volume", "battery"])
+        check_key(settings, "components", ["brightness", "battery", "volume", "processes"])
         check_key(settings, "net-interface", "")
         check_key(settings, "angle", 0.0)
+        check_key(settings, "battery-low-level", 20)
+        check_key(settings, "battery-low-interval", 3)
 
         self.set_property("name", settings["root-css-name"])
 
@@ -234,6 +239,14 @@ class Controls(Gtk.EventBox):
 
         if self.bat_label:
             self.bat_label.set_text("{}%".format(value))
+
+        if self.settings["battery-low-interval"] > 0:
+            t = int(time.time())
+            global bat_critical_last_check
+            if not charging and t - bat_critical_last_check >= self.settings["battery-low-interval"] * 60 and value <= \
+                    self.settings["battery-low-level"]:
+                subprocess.Popen('notify-send "Battery low!" -i {}'.format(icon_name), shell=True)
+                bat_critical_last_check = t
 
     def on_button_press(self, w, event, settings):
         if not self.popup_window.get_visible():

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -245,7 +245,7 @@ class Controls(Gtk.EventBox):
             global bat_critical_last_check
             if not charging and t - bat_critical_last_check >= self.settings["battery-low-interval"] * 60 and value <= \
                     self.settings["battery-low-level"]:
-                subprocess.Popen('notify-send "Battery low!" -i {}'.format(icon_name), shell=True)
+                subprocess.Popen('notify-send "Battery low! ({}%)" -i {}'.format(value, icon_name), shell=True)
                 bat_critical_last_check = t
 
     def on_button_press(self, w, event, settings):

--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -539,6 +539,31 @@ class PopupWindow(Gtk.Window):
 
             event_box.add(inner_vbox)
 
+        if "processes" in settings["components"]:
+            event_box = Gtk.EventBox()
+            event_box.connect("enter_notify_event", self.on_enter_notify_event)
+            event_box.connect("leave_notify_event", self.on_leave_notify_event)
+            event_box.connect('button-press-event', self.launch, "nwg-processes")
+
+            inner_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+            inner_hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+            inner_vbox.pack_start(inner_hbox, True, True, 6)
+            v_box.pack_start(event_box, True, True, 0)
+
+            self.proc_icon_name = "view-refresh-symbolic"
+            self.proc_image = Gtk.Image.new_from_icon_name("nwg-processes", Gtk.IconSize.MENU)
+
+            inner_hbox.pack_start(self.proc_image, False, False, 6)
+
+            self.proc_label = Gtk.Label.new("Processes")
+            inner_hbox.pack_start(self.proc_label, False, True, 6)
+
+            img = Gtk.Image()
+            update_image(img, "pan-end-symbolic", self.icon_size, self.icons_path)
+            inner_hbox.pack_end(img, False, True, 4)
+
+            event_box.add(inner_vbox)
+
         check_key(settings, "custom-items", [])
         if settings["custom-items"]:
             for item in settings["custom-items"]:

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -328,7 +328,9 @@ def main():
     win.set_size_request(0, win.get_allocated_width() * 0.7)
 
     list_processes(None)
-    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, settings["processes-interval-ms"], list_processes, None)
+
+    if settings["processes-interval-ms"] > 0:
+        Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, settings["processes-interval-ms"], list_processes, None)
 
     Gtk.main()
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -209,10 +209,11 @@ def main():
     win.connect("key-release-event", handle_keyboard)
 
     box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 6)
-    box.set_property("margin", 12)
+    box.set_property("margin", 6)
     win.add(box)
 
     wrapper = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
+    wrapper.set_property("name", "header")
     box.pack_start(wrapper, False, False, 0)
     desc_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
     wrapper.pack_start(desc_box, False, True, 0)
@@ -295,7 +296,8 @@ def main():
     provider = Gtk.CssProvider()
     style_context = Gtk.StyleContext()
     style_context.add_provider_for_screen(screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-    css = b""" #icon { margin-right: 6px } """
+    css = b""" #header { background-color: rgba(0, 0, 0, 0.3) } """
+    css += b""" #icon { margin-right: 6px } """
     css += b""" #img-empty { margin-right: 15px; border: 1px } """
     css += b""" #btn-kill { padding: 0; border: 0; margin-right: 6px } """
     css += b""" label { font-family: DejaVu Sans Mono, monospace } """

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -8,6 +8,15 @@ from gi.repository import Gtk, Gdk, GLib
 
 from nwg_panel.tools import get_config_dir, load_json, save_json, check_key, eprint
 
+W_KILL = 5
+W_PID = 7
+W_PPID = 7
+W_OWNER = 20
+W_CPU = 6
+W_MEM = 6
+W_NAME = 20
+W_WINDOW = 20
+
 common_settings = {}
 scrolled_window = None
 grid = Gtk.Grid()
@@ -34,7 +43,6 @@ def on_scroll(s_window, event):
     adj = s_window.get_vadjustment()
     global scroll
     scroll = adj.get_value()
-
 
 
 def on_list_changed(s_window, rect):
@@ -72,71 +80,33 @@ def list_processes(widget):
     else:
         scrolled_window.add(grid)
 
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>PID</b>")
-    lbl.set_property("halign", Gtk.Align.END)
-    # lbl.set_size_request(50, 0)
-    grid.attach(lbl, 1, 0, 1, 1)
-
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>PPID</b>")
-    lbl.set_property("halign", Gtk.Align.END)
-    # lbl.set_size_request(50, 0)
-    grid.attach(lbl, 2, 0, 1, 1)
-
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Owner</b>")
-    lbl.set_property("halign", Gtk.Align.END)
-    grid.attach(lbl, 3, 0, 1, 1)
-
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>CPU%</b>")
-    lbl.set_property("halign", Gtk.Align.END)
-    lbl.set_size_request(50, 0)
-    grid.attach(lbl, 4, 0, 1, 1)
-
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Mem%</b>")
-    lbl.set_property("halign", Gtk.Align.END)
-    lbl.set_size_request(50, 0)
-    grid.attach(lbl, 5, 0, 1, 1)
-
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Name</b>")
-    lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 7, 0, 1, 1)
-
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Window</b>")
-    lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 8, 0, 1, 1)
-
     idx = 1
     for pid in processes:
         cons = tree.find_by_pid(pid)
         if not cons or not common_settings["processes-background-only"]:
             lbl = Gtk.Label.new(str(pid))
-            # lbl.set_size_request(50, 0)
+            lbl.set_width_chars(W_PID)
             lbl.set_property("halign", Gtk.Align.END)
             grid.attach(lbl, 1, idx, 1, 1)
 
             lbl = Gtk.Label.new(str(processes[pid]["ppid"]))
-            # lbl.set_size_request(50, 0)
+            lbl.set_width_chars(W_PPID)
             lbl.set_property("halign", Gtk.Align.END)
             grid.attach(lbl, 2, idx, 1, 1)
 
             lbl = Gtk.Label.new(processes[pid]["username"])
+            lbl.set_width_chars(W_OWNER)
             lbl.set_property("halign", Gtk.Align.END)
             grid.attach(lbl, 3, idx, 1, 1)
 
             lbl = Gtk.Label.new("{}%".format(str(processes[pid]["cpu_percent"])))
+            lbl.set_width_chars(W_CPU)
             lbl.set_property("halign", Gtk.Align.END)
-            lbl.set_size_request(50, 0)
             grid.attach(lbl, 4, idx, 1, 1)
 
             lbl = Gtk.Label.new("{}%".format(str(round(processes[pid]["memory_percent"], 1))))
+            lbl.set_width_chars(W_MEM)
             lbl.set_property("halign", Gtk.Align.END)
-            lbl.set_size_request(50, 0)
             grid.attach(lbl, 5, idx, 1, 1)
 
             win_name = ""
@@ -152,6 +122,7 @@ def list_processes(widget):
 
             if win_name:
                 lbl = Gtk.Label.new(win_name)
+                lbl.set_width_chars(W_WINDOW)
                 lbl.set_property("halign", Gtk.Align.START)
                 grid.attach(lbl, 8, idx, 1, 1)
 
@@ -167,6 +138,7 @@ def list_processes(widget):
                 grid.attach(img, 6, idx, 1, 1)
 
             lbl = Gtk.Label.new(name)
+            lbl.set_width_chars(W_NAME)
             lbl.set_property("halign", Gtk.Align.START)
             grid.attach(lbl, 7, idx, 1, 1)
 
@@ -227,6 +199,59 @@ def main():
     box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 6)
     box.set_property("margin", 12)
     win.add(box)
+
+    wrapper = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
+    box.pack_start(wrapper, False, False, 0)
+    desc_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
+    wrapper.pack_start(desc_box, False, True, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>Kill</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    lbl.set_width_chars(W_KILL)
+    desc_box.pack_start(lbl, False, True, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>PID</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    lbl.set_width_chars(W_PID)
+    desc_box.pack_start(lbl, False, True, 0)
+
+    lbl_ppid = Gtk.Label()
+    lbl_ppid.set_markup("<b>PPID</b>")
+    lbl_ppid.set_property("halign", Gtk.Align.START)
+    lbl.set_width_chars(W_PPID)
+    desc_box.pack_start(lbl_ppid, False, True, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>Owner</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    lbl.set_width_chars(W_OWNER)
+    desc_box.pack_start(lbl, False, True, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>CPU%</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    lbl.set_width_chars(W_CPU)
+    desc_box.pack_start(lbl, True, True, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>Mem%</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    lbl.set_width_chars(W_MEM)
+    desc_box.pack_start(lbl, True, True, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>Name</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    lbl.set_width_chars(W_NAME)
+    desc_box.pack_start(lbl, True, True, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>Window</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    lbl.set_width_chars(W_WINDOW)
+    desc_box.pack_start(lbl, True, True, 0)
 
     global scrolled_window
     scrolled_window = Gtk.ScrolledWindow.new(None, None)

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -114,13 +114,13 @@ def list_processes(widget):
             idx += 1
     scrolled_window.show_all()
     scrolled_window.get_vadjustment().set_value(0)
-    return True
+    # return True
 
 
 def on_background_cb(check_button):
     common_settings["processes-background-only"] = check_button.get_active()
-    # GLib.timeout_add(100, list_processes, None)
-    list_processes(None)
+    GLib.timeout_add(1000, list_processes, None)
+    # list_processes(None)
 
 
 def on_own_cb(check_button):

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -78,73 +78,69 @@ def list_processes(widget):
     lbl = Gtk.Label()
     lbl.set_markup("<b>PID</b>")
     lbl.set_property("halign", Gtk.Align.END)
-    lbl.set_size_request(100, 0)
+    lbl.set_size_request(50, 0)
     grid.attach(lbl, 1, 0, 1, 1)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>PPID</b>")
+    lbl.set_property("halign", Gtk.Align.END)
+    lbl.set_size_request(50, 0)
+    grid.attach(lbl, 2, 0, 1, 1)
 
     lbl = Gtk.Label()
     lbl.set_markup("<b>Owner</b>")
     lbl.set_property("halign", Gtk.Align.END)
-    grid.attach(lbl, 2, 0, 1, 1)
-
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>CPU</b>")
-    lbl.set_property("halign", Gtk.Align.END)
-    lbl.set_size_request(50, 0)
     grid.attach(lbl, 3, 0, 1, 1)
 
     lbl = Gtk.Label()
-    lbl.set_markup("<b>Mem</b>")
+    lbl.set_markup("<b>CPU%</b>")
     lbl.set_property("halign", Gtk.Align.END)
     lbl.set_size_request(50, 0)
     grid.attach(lbl, 4, 0, 1, 1)
 
     lbl = Gtk.Label()
+    lbl.set_markup("<b>Mem%</b>")
+    lbl.set_property("halign", Gtk.Align.END)
+    lbl.set_size_request(50, 0)
+    grid.attach(lbl, 5, 0, 1, 1)
+
+    lbl = Gtk.Label()
     lbl.set_markup("<b>Name</b>")
     lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 6, 0, 1, 1)
+    grid.attach(lbl, 7, 0, 1, 1)
 
     lbl = Gtk.Label()
     lbl.set_markup("<b>Window</b>")
     lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 7, 0, 1, 1)
+    grid.attach(lbl, 8, 0, 1, 1)
 
     idx = 1
     for pid in processes:
         cons = tree.find_by_pid(pid)
         if not cons or not common_settings["processes-background-only"]:
-            lbl = Gtk.Label.new("{}->{}".format(str( processes[pid]["ppid"]), str(pid)))
+            lbl = Gtk.Label.new(str(pid))
             lbl.set_property("halign", Gtk.Align.END)
-            lbl.set_size_request(100, 0)
+            lbl.set_size_request(50, 0)
             grid.attach(lbl, 1, idx, 1, 1)
+
+            lbl = Gtk.Label.new(str(processes[pid]["ppid"]))
+            lbl.set_property("halign", Gtk.Align.END)
+            lbl.set_size_request(50, 0)
+            grid.attach(lbl, 2, idx, 1, 1)
 
             lbl = Gtk.Label.new(processes[pid]["username"])
             lbl.set_property("halign", Gtk.Align.END)
-            grid.attach(lbl, 2, idx, 1, 1)
+            grid.attach(lbl, 3, idx, 1, 1)
 
             lbl = Gtk.Label.new("{}%".format(str(processes[pid]["cpu_percent"])))
             lbl.set_property("halign", Gtk.Align.END)
             lbl.set_size_request(50, 0)
-            grid.attach(lbl, 3, idx, 1, 1)
+            grid.attach(lbl, 4, idx, 1, 1)
 
             lbl = Gtk.Label.new("{}%".format(str(round(processes[pid]["memory_percent"], 1))))
             lbl.set_property("halign", Gtk.Align.END)
             lbl.set_size_request(50, 0)
-            grid.attach(lbl, 4, idx, 1, 1)
-
-            name = processes[pid]["name"]
-            if theme.lookup_icon(name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
-                img = Gtk.Image.new_from_icon_name(name, Gtk.IconSize.MENU)
-                img.set_property("halign", Gtk.Align.END)
-                grid.attach(img, 5, idx, 1, 1)
-
-            lbl = Gtk.Label.new(name)
-            lbl.set_property("halign", Gtk.Align.START)
-            grid.attach(lbl, 6, idx, 1, 1)
-
-            if processes[pid]["username"] == user:
-                btn = Gtk.Button.new_from_icon_name("gtk-close", Gtk.IconSize.MENU)
-                btn.connect("clicked", terminate, pid)
-                grid.attach(btn, 0, idx, 1, 1)
+            grid.attach(lbl, 5, idx, 1, 1)
 
             win_name = ""
             if cons:
@@ -160,7 +156,27 @@ def list_processes(widget):
             if win_name:
                 lbl = Gtk.Label.new(win_name)
                 lbl.set_property("halign", Gtk.Align.START)
-                grid.attach(lbl, 7, idx, 1, 1)
+                grid.attach(lbl, 8, idx, 1, 1)
+
+            name = processes[pid]["name"]
+            if theme.lookup_icon(name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
+                img = Gtk.Image.new_from_icon_name(name, Gtk.IconSize.MENU)
+                img.set_property("halign", Gtk.Align.END)
+                grid.attach(img, 6, idx, 1, 1)
+            # fallback icon name
+            elif win_name and theme.lookup_icon(win_name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
+                img = Gtk.Image.new_from_icon_name(win_name, Gtk.IconSize.MENU)
+                img.set_property("halign", Gtk.Align.END)
+                grid.attach(img, 6, idx, 1, 1)
+
+            lbl = Gtk.Label.new(name)
+            lbl.set_property("halign", Gtk.Align.START)
+            grid.attach(lbl, 7, idx, 1, 1)
+
+            if processes[pid]["username"] == user:
+                btn = Gtk.Button.new_from_icon_name("gtk-close", Gtk.IconSize.MENU)
+                btn.connect("clicked", terminate, pid)
+                grid.attach(btn, 0, idx, 1, 1)
 
             idx += 1
 
@@ -220,7 +236,7 @@ def main():
     scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.ALWAYS)
     # scrolled_window.set_propagate_natural_width(True)
     # scrolled_window.set_propagate_natural_height(True)
-    # scrolled_window.connect("size-allocate", on_list_changed)
+
     scrolled_window.connect("scroll-event", on_scroll)
     box.pack_start(scrolled_window, True, True, 0)
 
@@ -250,7 +266,7 @@ def main():
     win.show_all()
 
     list_processes(None)
-    GLib.timeout_add(1000, list_processes, None)
+    GLib.timeout_add(2000, list_processes, None)
 
     Gtk.main()
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -94,7 +94,10 @@ def list_processes(widget):
             lbl.set_xalign(0)
             grid.attach(lbl, 2, idx, 1, 1)
 
-            lbl = Gtk.Label.new(processes[pid]["username"])
+            owner = processes[pid]["username"]
+            if len(owner) > W_OWNER:
+                owner = "{}…".format(owner[:W_OWNER - 1])
+            lbl = Gtk.Label.new(owner)
             lbl.set_width_chars(W_OWNER)
             lbl.set_xalign(0)
             grid.attach(lbl, 3, idx, 1, 1)
@@ -214,10 +217,6 @@ def main():
     desc_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
     wrapper.pack_start(desc_box, False, True, 0)
 
-    # lbl = Gtk.Label()
-    # lbl.set_markup(" ")
-    # lbl.set_width_chars(W_KILL)
-    # lbl.set_xalign(0)
     img = Gtk.Image()
     img.set_property("name", "img-empty")
     desc_box.pack_start(img, False, False, 0)

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -210,6 +210,7 @@ def main():
 
     box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 6)
     box.set_property("margin", 6)
+    box.set_property("vexpand", True)
     win.add(box)
 
     wrapper = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
@@ -268,6 +269,10 @@ def main():
     scrolled_window.set_propagate_natural_height(True)
     # scrolled_window.connect("scroll-event", on_scroll)
     box.pack_start(scrolled_window, True, True, 0)
+
+    dist = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
+    dist.set_property("vexpand", True)
+    box.pack_start(dist, True, True, 0)
 
     hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 12)
     box.pack_start(hbox, False, False, 0)

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -28,8 +28,6 @@ def terminate(btn, pid):
         os.kill(pid, 15)
     except Exception as e:
         eprint(e)
-    # Wait a second for children processes to die
-    # GLib.timeout_add(1000, list_processes, None)
 
 
 def on_scroll(s_window, event):
@@ -55,7 +53,6 @@ def list_processes(widget):
         if proc.info['username'] == os.getenv('USER') or not common_settings["processes-own-only"]:
             processes[proc.info['pid']] = proc.info
 
-
     if scrolled_window and scrolled_window.get_children():
         viewport = scrolled_window.get_children()[0]
     else:
@@ -78,13 +75,13 @@ def list_processes(widget):
     lbl = Gtk.Label()
     lbl.set_markup("<b>PID</b>")
     lbl.set_property("halign", Gtk.Align.END)
-    lbl.set_size_request(50, 0)
+    # lbl.set_size_request(50, 0)
     grid.attach(lbl, 1, 0, 1, 1)
 
     lbl = Gtk.Label()
     lbl.set_markup("<b>PPID</b>")
     lbl.set_property("halign", Gtk.Align.END)
-    lbl.set_size_request(50, 0)
+    # lbl.set_size_request(50, 0)
     grid.attach(lbl, 2, 0, 1, 1)
 
     lbl = Gtk.Label()
@@ -119,13 +116,13 @@ def list_processes(widget):
         cons = tree.find_by_pid(pid)
         if not cons or not common_settings["processes-background-only"]:
             lbl = Gtk.Label.new(str(pid))
+            # lbl.set_size_request(50, 0)
             lbl.set_property("halign", Gtk.Align.END)
-            lbl.set_size_request(50, 0)
             grid.attach(lbl, 1, idx, 1, 1)
 
             lbl = Gtk.Label.new(str(processes[pid]["ppid"]))
+            # lbl.set_size_request(50, 0)
             lbl.set_property("halign", Gtk.Align.END)
-            lbl.set_size_request(50, 0)
             grid.attach(lbl, 2, idx, 1, 1)
 
             lbl = Gtk.Label.new(processes[pid]["username"])
@@ -234,8 +231,8 @@ def main():
     global scrolled_window
     scrolled_window = Gtk.ScrolledWindow.new(None, None)
     scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.ALWAYS)
-    # scrolled_window.set_propagate_natural_width(True)
-    # scrolled_window.set_propagate_natural_height(True)
+    scrolled_window.set_propagate_natural_width(True)
+    scrolled_window.set_propagate_natural_height(True)
 
     scrolled_window.connect("scroll-event", on_scroll)
     box.pack_start(scrolled_window, True, True, 0)

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -59,7 +59,7 @@ def terminate(btn, pid):
     list_processes(None)
 
 
-def list_processes(widget):
+def list_processes(widget, once=False):
     tree = Connection().get_tree()
     processes = {}
 
@@ -180,7 +180,8 @@ def list_processes(widget):
 
     grid.show_all()
 
-    return True
+    if not once:
+        return True
 
 
 def on_background_cb(check_button):
@@ -331,6 +332,8 @@ def main():
 
     if settings["processes-interval-ms"] > 0:
         Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, settings["processes-interval-ms"], list_processes, None)
+    else:
+        GLib.timeout_add(1000, list_processes, None, True)
 
     Gtk.main()
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -19,6 +19,12 @@ W_MEM = 7
 W_NAME = 24
 W_WINDOW = 24
 
+# Fallback icon names dict: win_name -> icon_name
+aliases = {
+    "Gimp-2.10": "gimp",
+    "nwg-panel-config": "nwg-panel"
+}
+
 settings = {}  # nwg-panel common settings
 scrolled_window = None
 grid = Gtk.Grid()
@@ -132,6 +138,12 @@ def list_processes(widget):
             # fallback icon name
             elif win_name and theme.lookup_icon(win_name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
                 img = Gtk.Image.new_from_icon_name(win_name, Gtk.IconSize.MENU)
+                img.set_property("name", "icon")
+                img.set_property("halign", Gtk.Align.END)
+                grid.attach(img, 6, idx, 1, 1)
+            elif win_name and win_name in aliases and theme.lookup_icon(aliases[win_name], 16,
+                                                                        Gtk.IconLookupFlags.FORCE_SYMBOLIC):
+                img = Gtk.Image.new_from_icon_name(aliases[win_name], Gtk.IconSize.MENU)
                 img.set_property("name", "icon")
                 img.set_property("halign", Gtk.Align.END)
                 grid.attach(img, 6, idx, 1, 1)

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python3
+
+"""
+nwg-shell helper script to preview system processes
+Copyright (c) 2023 Piotr Miller
+e-mail: nwg.piotr@gmail.com
+GitHub: https://github.com/nwg-piotr/nwg-panel
+Project: https://nwg-piotr.github.io/nwg-shell
+License: MIT
+"""
+
 import os
 
 import psutil
@@ -57,6 +68,8 @@ def list_processes(widget):
         if proc.info['username'] == os.getenv('USER') or not settings["processes-own-only"]:
             processes[proc.info['pid']] = proc.info
 
+    # At first, we need to add grid to the scrolled window (as in former add_with_viewport).
+    # In next iterations, we add the grid directly to already existing viewport, to avoid the scrolled window floating.
     if scrolled_window and scrolled_window.get_children():
         viewport = scrolled_window.get_children()[0]
     else:

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -24,6 +24,7 @@ def handle_keyboard(win, event):
 def terminate(btn, pid):
     print("Killing {}".format(pid))
     os.kill(pid, 2)
+    list_processes(None)
 
 
 def list_processes(widget):
@@ -118,6 +119,7 @@ def list_processes(widget):
 
 def on_background_cb(check_button):
     common_settings["processes-background-only"] = check_button.get_active()
+    # GLib.timeout_add(100, list_processes, None)
     list_processes(None)
 
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -4,10 +4,13 @@ import psutil
 from i3ipc import Connection
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gtk, Gdk, GLib, Gio
+from gi.repository import Gtk, Gdk, GLib
 
-grid = None
+from nwg_panel.tools import get_config_dir, load_json, save_json, check_key, eprint
+
+common_settings = {}
 protected = ["systemd", "bash"]
+grid = Gtk.Grid()
 
 theme = Gtk.IconTheme.get_default()
 
@@ -21,13 +24,16 @@ def terminate(btn, pid):
     os.kill(pid, 2)
 
 
-def list_processes(box):
+def list_processes(widget, scrolled_window):
     tree = Connection().get_tree()
     processes = {}
 
     for proc in psutil.process_iter(['pid', 'ppid', 'name', 'username']):
-        if proc.info['username'] == os.getenv('USER') and proc.info['ppid'] == 1:
-            processes[proc.info['pid']] = proc.info['name']
+        # if proc.info['username'] == os.getenv('USER') and proc.info['ppid'] == 1:
+        processes[proc.info['pid']] = proc.info['name']
+
+    for child in scrolled_window.get_children():
+        scrolled_window.remove(child)
 
     global grid
     if grid:
@@ -36,7 +42,7 @@ def list_processes(box):
     grid = Gtk.Grid.new()
     grid.set_row_spacing(6)
     grid.set_column_spacing(6)
-    box.pack_start(grid, True, True, 0)
+    scrolled_window.add(grid)
 
     lbl = Gtk.Label()
     lbl.set_markup("<b>PID</b>")
@@ -44,18 +50,23 @@ def list_processes(box):
     grid.attach(lbl, 0, 0, 1, 1)
 
     lbl = Gtk.Label()
+    lbl.set_markup("<b>User</b>")
+    lbl.set_property("halign", Gtk.Align.END)
+    grid.attach(lbl, 1, 0, 1, 1)
+
+    lbl = Gtk.Label()
     lbl.set_markup("<b>Name</b>")
     lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 2, 0, 1, 1)
+    grid.attach(lbl, 3, 0, 1, 1)
 
     lbl = Gtk.Label()
     lbl.set_markup("<b>Kill</b>")
     lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 3, 0, 1, 1)
+    grid.attach(lbl, 4, 0, 1, 1)
 
     idx = 1
     for pid in processes:
-        if not tree.find_by_pid(pid):
+        if not tree.find_by_pid(pid) or common_settings["processes-background-only"]:
             lbl = Gtk.Label.new(str(pid))
             lbl.set_property("halign", Gtk.Align.END)
             grid.attach(lbl, 0, idx, 1, 1)
@@ -65,38 +76,73 @@ def list_processes(box):
             if theme.lookup_icon(name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
                 img = Gtk.Image.new_from_icon_name(name, Gtk.IconSize.MENU)
                 img.set_property("halign", Gtk.Align.END)
-                grid.attach(img, 1, idx, 1, 1)
+                grid.attach(img, 2, idx, 1, 1)
 
             lbl = Gtk.Label.new(name)
             lbl.set_property("halign", Gtk.Align.START)
-            grid.attach(lbl, 2, idx, 1, 1)
-
-
+            grid.attach(lbl, 3, idx, 1, 1)
 
             if processes[pid] not in protected:
                 btn = Gtk.Button.new_from_icon_name("gtk-close", Gtk.IconSize.MENU)
                 btn.connect("clicked", terminate, pid)
-                grid.attach(btn, 3, idx, 1, 1)
+                grid.attach(btn, 4, idx, 1, 1)
 
             idx += 1
     grid.show_all()
     return True
 
 
+def on_background_cb(check_button):
+    common_settings["processes-background-only"] = check_button.get_active()
+
+
 def main():
+    GLib.set_prgname('nwg-processes')
+    global common_settings
+    common_settings = load_json(os.path.join(get_config_dir(), "common-settings.json"))
+    defaults = {
+        "processes-background-only": True,
+        "processes-own-only": True
+    }
+    for key in defaults:
+        check_key(common_settings, key, defaults[key])
+    eprint("Common settings", common_settings)
+
     win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     win.connect('destroy', Gtk.main_quit)
     win.connect("key-release-event", handle_keyboard)
 
-    box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
+    box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 6)
     box.set_property("margin", 12)
     win.add(box)
 
-    list_processes(box)
+    scrolled_window = Gtk.ScrolledWindow.new(None, None)
+    scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.ALWAYS)
+    scrolled_window.set_propagate_natural_width(True)
+    scrolled_window.set_propagate_natural_height(True)
+    box.pack_start(scrolled_window, True, True, 0)
+
+    hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 12)
+    box.pack_start(hbox, False, False, 0)
+
+    cb = Gtk.CheckButton.new_with_label("Background only")
+    cb.set_active(common_settings["processes-background-only"])
+    cb.connect("toggled", on_background_cb)
+    hbox.pack_start(cb, False, False, 6)
+
+    btn = Gtk.Button.new_with_label("Close")
+    hbox.pack_end(btn, False, False, 0)
+    btn.connect("clicked", Gtk.main_quit)
+
+    btn = Gtk.Button.new_with_label("Refresh")
+    hbox.pack_end(btn, False, False, 0)
+    btn.connect("clicked", list_processes, scrolled_window)
+
+    list_processes(None, scrolled_window)
 
     win.show_all()
 
-    GLib.timeout_add(1000, list_processes, box)
+    # GLib.timeout_add(1000, list_processes, scrolled_window)
     Gtk.main()
 
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -32,9 +32,8 @@ def list_processes(widget):
 
     user = os.getenv('USER')
     for proc in psutil.process_iter(['pid', 'ppid', 'name', 'username']):
-        print(proc.info['ppid'])
         if proc.info['username'] == os.getenv('USER') or not common_settings["processes-own-only"]:
-            # if proc.info['ppid'] == 1:
+            # if proc.info['ppid'] not in pids:
             processes[proc.info['pid']] = proc.info
 
     for child in scrolled_window.get_children():

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -290,7 +290,7 @@ def main():
     win.show_all()
 
     list_processes(None)
-    GLib.timeout_add(2000, list_processes, None)
+    Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, 2000, list_processes, None)
 
     Gtk.main()
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -35,7 +35,7 @@ def list_processes(widget):
     processes = {}
 
     user = os.getenv('USER')
-    for proc in psutil.process_iter(['pid', 'ppid', 'name', 'username']):
+    for proc in psutil.process_iter(['pid', 'name', 'username', 'cpu_percent', 'memory_percent']):
         if proc.info['username'] == os.getenv('USER') or not common_settings["processes-own-only"]:
             processes[proc.info['pid']] = proc.info
 
@@ -49,7 +49,7 @@ def list_processes(widget):
     grid = Gtk.Grid.new()
     grid.set_row_spacing(3)
     grid.set_row_homogeneous(True)
-    grid.set_column_spacing(6)
+    grid.set_column_spacing(9)
     scrolled_window.add(grid)
 
     lbl = Gtk.Label()
@@ -63,14 +63,24 @@ def list_processes(widget):
     grid.attach(lbl, 2, 0, 1, 1)
 
     lbl = Gtk.Label()
+    lbl.set_markup("<b>CPU</b>")
+    lbl.set_property("halign", Gtk.Align.END)
+    grid.attach(lbl, 3, 0, 1, 1)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>Mem</b>")
+    lbl.set_property("halign", Gtk.Align.END)
+    grid.attach(lbl, 4, 0, 1, 1)
+
+    lbl = Gtk.Label()
     lbl.set_markup("<b>Name</b>")
     lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 4, 0, 1, 1)
+    grid.attach(lbl, 6, 0, 1, 1)
 
     lbl = Gtk.Label()
     lbl.set_markup("<b>Window</b>")
     lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 5, 0, 1, 1)
+    grid.attach(lbl, 7, 0, 1, 1)
 
     idx = 1
     for pid in processes:
@@ -84,15 +94,23 @@ def list_processes(widget):
             lbl.set_property("halign", Gtk.Align.END)
             grid.attach(lbl, 2, idx, 1, 1)
 
+            lbl = Gtk.Label.new("{}%".format(str(processes[pid]["cpu_percent"])))
+            lbl.set_property("halign", Gtk.Align.END)
+            grid.attach(lbl, 3, idx, 1, 1)
+
+            lbl = Gtk.Label.new("{}%".format(str(round(processes[pid]["memory_percent"], 1))))
+            lbl.set_property("halign", Gtk.Align.END)
+            grid.attach(lbl, 4, idx, 1, 1)
+
             name = processes[pid]["name"]
             if theme.lookup_icon(name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
                 img = Gtk.Image.new_from_icon_name(name, Gtk.IconSize.MENU)
                 img.set_property("halign", Gtk.Align.END)
-                grid.attach(img, 3, idx, 1, 1)
+                grid.attach(img, 5, idx, 1, 1)
 
             lbl = Gtk.Label.new(name)
             lbl.set_property("halign", Gtk.Align.START)
-            grid.attach(lbl, 4, idx, 1, 1)
+            grid.attach(lbl, 6, idx, 1, 1)
 
             if processes[pid]["username"] == user:
                 btn = Gtk.Button.new_from_icon_name("gtk-close", Gtk.IconSize.MENU)
@@ -113,7 +131,7 @@ def list_processes(widget):
             if win_name:
                 lbl = Gtk.Label.new(win_name)
                 lbl.set_property("halign", Gtk.Align.START)
-                grid.attach(lbl, 5, idx, 1, 1)
+                grid.attach(lbl, 7, idx, 1, 1)
 
             idx += 1
     scrolled_window.show_all()

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -158,13 +158,17 @@ def list_processes(widget):
 
 def on_background_cb(check_button):
     common_settings["processes-background-only"] = check_button.get_active()
+    save_json(common_settings, os.path.join(get_config_dir(), "common-settings.json"))
     if window_lbl:
         window_lbl.set_visible(not common_settings["processes-background-only"])
+
     list_processes(None)
 
 
 def on_own_cb(check_button):
     common_settings["processes-own-only"] = check_button.get_active()
+    save_json(common_settings, os.path.join(get_config_dir(), "common-settings.json"))
+
     list_processes(None)
 
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -21,8 +21,6 @@ common_settings = {}
 scrolled_window = None
 grid = Gtk.Grid()
 window_lbl = None
-scroll = 0.0
-# max_num_items = 0
 
 theme = Gtk.IconTheme.get_default()
 
@@ -40,12 +38,6 @@ def terminate(btn, pid):
         eprint(e)
 
     list_processes(None)
-
-
-def on_scroll(s_window, event):
-    adj = s_window.get_vadjustment()
-    global scroll
-    scroll = adj.get_value()
 
 
 def list_processes(widget):
@@ -267,7 +259,6 @@ def main():
     scrolled_window = Gtk.ScrolledWindow.new(None, None)
     scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
     scrolled_window.set_propagate_natural_height(True)
-    # scrolled_window.connect("scroll-event", on_scroll)
     box.pack_start(scrolled_window, True, True, 0)
 
     dist = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -3,23 +3,24 @@ import os
 import psutil
 from i3ipc import Connection
 import gi
+
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GLib
 
 from nwg_panel.tools import get_config_dir, load_json, save_json, check_key, eprint
 
-W_KILL = 5
-W_PID = 7
-W_PPID = 7
-W_OWNER = 20
-W_CPU = 6
-W_MEM = 6
-W_NAME = 20
-W_WINDOW = 20
+W_PID = 10
+W_PPID = 10
+W_OWNER = 10
+W_CPU = 7
+W_MEM = 7
+W_NAME = 24
+W_WINDOW = 24
 
 common_settings = {}
 scrolled_window = None
 grid = Gtk.Grid()
+window_lbl = None
 scroll = 0.0
 max_num_items = 0
 
@@ -73,7 +74,6 @@ def list_processes(widget):
     grid = Gtk.Grid.new()
     grid.set_row_spacing(3)
     grid.set_row_homogeneous(True)
-    grid.set_column_spacing(9)
 
     if viewport:
         viewport.add(grid)
@@ -86,27 +86,27 @@ def list_processes(widget):
         if not cons or not common_settings["processes-background-only"]:
             lbl = Gtk.Label.new(str(pid))
             lbl.set_width_chars(W_PID)
-            lbl.set_property("halign", Gtk.Align.END)
+            lbl.set_xalign(0)
             grid.attach(lbl, 1, idx, 1, 1)
 
             lbl = Gtk.Label.new(str(processes[pid]["ppid"]))
             lbl.set_width_chars(W_PPID)
-            lbl.set_property("halign", Gtk.Align.END)
+            lbl.set_xalign(0)
             grid.attach(lbl, 2, idx, 1, 1)
 
             lbl = Gtk.Label.new(processes[pid]["username"])
             lbl.set_width_chars(W_OWNER)
-            lbl.set_property("halign", Gtk.Align.END)
+            lbl.set_xalign(0)
             grid.attach(lbl, 3, idx, 1, 1)
 
             lbl = Gtk.Label.new("{}%".format(str(processes[pid]["cpu_percent"])))
             lbl.set_width_chars(W_CPU)
-            lbl.set_property("halign", Gtk.Align.END)
+            lbl.set_xalign(0)
             grid.attach(lbl, 4, idx, 1, 1)
 
             lbl = Gtk.Label.new("{}%".format(str(round(processes[pid]["memory_percent"], 1))))
             lbl.set_width_chars(W_MEM)
-            lbl.set_property("halign", Gtk.Align.END)
+            lbl.set_xalign(0)
             grid.attach(lbl, 5, idx, 1, 1)
 
             win_name = ""
@@ -123,27 +123,34 @@ def list_processes(widget):
             if win_name:
                 lbl = Gtk.Label.new(win_name)
                 lbl.set_width_chars(W_WINDOW)
-                lbl.set_property("halign", Gtk.Align.START)
+                lbl.set_xalign(0)
                 grid.attach(lbl, 8, idx, 1, 1)
 
             name = processes[pid]["name"]
             if theme.lookup_icon(name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
                 img = Gtk.Image.new_from_icon_name(name, Gtk.IconSize.MENU)
+                img.set_property("name", "icon")
                 img.set_property("halign", Gtk.Align.END)
                 grid.attach(img, 6, idx, 1, 1)
             # fallback icon name
             elif win_name and theme.lookup_icon(win_name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
                 img = Gtk.Image.new_from_icon_name(win_name, Gtk.IconSize.MENU)
+                img.set_property("name", "icon")
                 img.set_property("halign", Gtk.Align.END)
                 grid.attach(img, 6, idx, 1, 1)
 
+            if len(name) > W_NAME:
+                name = "{}…".format(name[:W_NAME - 1])
             lbl = Gtk.Label.new(name)
             lbl.set_width_chars(W_NAME)
-            lbl.set_property("halign", Gtk.Align.START)
+            lbl.set_xalign(0)
             grid.attach(lbl, 7, idx, 1, 1)
 
             if processes[pid]["username"] == user:
                 btn = Gtk.Button.new_from_icon_name("gtk-close", Gtk.IconSize.MENU)
+                btn.set_property("name", "btn-kill")
+                btn.set_property("hexpand", False)
+                btn.set_property("halign", Gtk.Align.START)
                 btn.connect("clicked", terminate, pid)
                 grid.attach(btn, 0, idx, 1, 1)
 
@@ -170,6 +177,8 @@ def on_background_cb(check_button):
     common_settings["processes-background-only"] = check_button.get_active()
     global max_num_items
     max_num_items = 0
+    if window_lbl:
+        window_lbl.set_visible(not common_settings["processes-background-only"])
     list_processes(None)
 
 
@@ -205,53 +214,53 @@ def main():
     desc_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
     wrapper.pack_start(desc_box, False, True, 0)
 
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Kill</b>")
-    lbl.set_property("halign", Gtk.Align.START)
-    lbl.set_width_chars(W_KILL)
-    desc_box.pack_start(lbl, False, True, 0)
+    # lbl = Gtk.Label()
+    # lbl.set_markup(" ")
+    # lbl.set_width_chars(W_KILL)
+    # lbl.set_xalign(0)
+    img = Gtk.Image()
+    img.set_property("name", "img-empty")
+    desc_box.pack_start(img, False, False, 0)
 
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>PID</b>")
-    lbl.set_property("halign", Gtk.Align.START)
+    lbl = Gtk.Label.new("PID")
     lbl.set_width_chars(W_PID)
-    desc_box.pack_start(lbl, False, True, 0)
+    lbl.set_xalign(0)
+    desc_box.pack_start(lbl, False, False, 0)
 
-    lbl_ppid = Gtk.Label()
-    lbl_ppid.set_markup("<b>PPID</b>")
-    lbl_ppid.set_property("halign", Gtk.Align.START)
+    lbl = Gtk.Label.new("PPID")
     lbl.set_width_chars(W_PPID)
-    desc_box.pack_start(lbl_ppid, False, True, 0)
+    lbl.set_xalign(0)
+    desc_box.pack_start(lbl, False, False, 0)
 
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Owner</b>")
-    lbl.set_property("halign", Gtk.Align.START)
+    lbl = Gtk.Label.new("Owner")
     lbl.set_width_chars(W_OWNER)
-    desc_box.pack_start(lbl, False, True, 0)
+    lbl.set_xalign(0)
+    desc_box.pack_start(lbl, False, False, 0)
 
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>CPU%</b>")
-    lbl.set_property("halign", Gtk.Align.START)
+    lbl = Gtk.Label.new("CPU%")
     lbl.set_width_chars(W_CPU)
+    lbl.set_xalign(0)
     desc_box.pack_start(lbl, True, True, 0)
 
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Mem%</b>")
-    lbl.set_property("halign", Gtk.Align.START)
+    lbl = Gtk.Label.new("Mem%")
     lbl.set_width_chars(W_MEM)
+    lbl.set_xalign(0)
     desc_box.pack_start(lbl, True, True, 0)
 
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Name</b>")
-    lbl.set_property("halign", Gtk.Align.START)
+    img = Gtk.Image()
+    img.set_property("name", "icon")
+    desc_box.pack_start(img, True, True, 0)
+
+    lbl = Gtk.Label.new("Name")
     lbl.set_width_chars(W_NAME)
+    lbl.set_xalign(0)
     desc_box.pack_start(lbl, True, True, 0)
 
-    lbl = Gtk.Label()
-    lbl.set_markup("<b>Window</b>")
-    lbl.set_property("halign", Gtk.Align.START)
-    lbl.set_width_chars(W_WINDOW)
-    desc_box.pack_start(lbl, True, True, 0)
+    global window_lbl
+    window_lbl = Gtk.Label.new("Window")
+    window_lbl.set_width_chars(W_WINDOW)
+    window_lbl.set_xalign(0)
+    desc_box.pack_start(window_lbl, True, True, 0)
 
     global scrolled_window
     scrolled_window = Gtk.ScrolledWindow.new(None, None)
@@ -281,9 +290,19 @@ def main():
     hbox.pack_end(btn, False, False, 0)
     btn.connect("clicked", Gtk.main_quit)
 
-    btn = Gtk.Button.new_with_label("Refresh")
-    hbox.pack_end(btn, False, False, 0)
-    btn.connect("clicked", list_processes)
+    # btn = Gtk.Button.new_with_label("Refresh")
+    # hbox.pack_end(btn, False, False, 0)
+    # btn.connect("clicked", list_processes)
+
+    screen = Gdk.Screen.get_default()
+    provider = Gtk.CssProvider()
+    style_context = Gtk.StyleContext()
+    style_context.add_provider_for_screen(screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+    css = b""" #icon { margin-right: 6px } """
+    css += b""" #img-empty { margin-right: 15px; border: 1px } """
+    css += b""" #btn-kill { padding: 0; border: 0; margin-right: 6px } """
+    css += b""" label { font-family: DejaVu Sans Mono, monospace } """
+    provider.load_from_data(css)
 
     win.show_all()
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -213,7 +213,6 @@ def main():
         check_key(settings, key, defaults[key])
     if not sway:
         settings["processes-background-only"] = False
-    eprint("Common settings", settings)
 
     win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
     win.connect('destroy', Gtk.main_quit)

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -56,10 +56,10 @@ def terminate(btn, pid):
     except Exception as e:
         eprint(e)
 
-    list_processes(None)
+    list_processes()
 
 
-def list_processes(widget, once=False):
+def list_processes(once=False):
     tree = Connection().get_tree()
     processes = {}
 
@@ -190,14 +190,14 @@ def on_background_cb(check_button):
     if window_lbl:
         window_lbl.set_visible(not settings["processes-background-only"])
 
-    list_processes(None)
+    list_processes()
 
 
 def on_own_cb(check_button):
     settings["processes-own-only"] = check_button.get_active()
     save_json(settings, os.path.join(get_config_dir(), "common-settings.json"))
 
-    list_processes(None)
+    list_processes()
 
 
 def main():
@@ -327,12 +327,12 @@ def main():
 
     win.set_size_request(0, win.get_allocated_width() * 0.5)
 
-    list_processes(None)
+    list_processes()
 
     if settings["processes-interval-ms"] > 0:
-        Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, settings["processes-interval-ms"], list_processes, None)
+        Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, settings["processes-interval-ms"], list_processes)
     else:
-        GLib.timeout_add(1000, list_processes, None, True)
+        GLib.timeout_add(1000, list_processes, True)
 
     Gtk.main()
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -280,11 +280,11 @@ def main():
     provider = Gtk.CssProvider()
     style_context = Gtk.StyleContext()
     style_context.add_provider_for_screen(screen, provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
-    css = b""" #header { background-color: rgba(0, 0, 0, 0.3) } """
-    css += b""" #icon { margin-right: 6px } """
-    css += b""" #img-empty { margin-right: 15px; border: 1px } """
-    css += b""" #btn-kill { padding: 0; border: 0; margin-right: 6px } """
-    css += b""" label { font-family: DejaVu Sans Mono, monospace } """
+    css = b""" #header { background-color: rgba(0, 0, 0, 0.3) }
+        #icon { margin-right: 6px }
+        #img-empty { margin-right: 15px; border: 1px }
+        #btn-kill { padding: 0; border: 0; margin-right: 6px }
+        label { font-family: DejaVu Sans Mono, monospace } """
     provider.load_from_data(css)
 
     win.show_all()

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -32,8 +32,9 @@ def list_processes(widget):
 
     user = os.getenv('USER')
     for proc in psutil.process_iter(['pid', 'ppid', 'name', 'username']):
+        print(proc.info['ppid'])
         if proc.info['username'] == os.getenv('USER') or not common_settings["processes-own-only"]:
-            # if proc.info['ppid'] == 1
+            # if proc.info['ppid'] == 1:
             processes[proc.info['pid']] = proc.info
 
     for child in scrolled_window.get_children():

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -1,0 +1,104 @@
+import os
+
+import psutil
+from i3ipc import Connection
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk, Gdk, GLib, Gio
+
+grid = None
+protected = ["systemd", "bash"]
+
+theme = Gtk.IconTheme.get_default()
+
+def handle_keyboard(win, event):
+    if event.type == Gdk.EventType.KEY_RELEASE and event.keyval == Gdk.KEY_Escape:
+        win.destroy()
+
+
+def terminate(btn, pid):
+    print("Killing {}".format(pid))
+    os.kill(pid, 2)
+
+
+def list_processes(box):
+    tree = Connection().get_tree()
+    processes = {}
+
+    for proc in psutil.process_iter(['pid', 'ppid', 'name', 'username']):
+        if proc.info['username'] == os.getenv('USER') and proc.info['ppid'] == 1:
+            processes[proc.info['pid']] = proc.info['name']
+
+    global grid
+    if grid:
+        grid.destroy()
+
+    grid = Gtk.Grid.new()
+    grid.set_row_spacing(6)
+    grid.set_column_spacing(6)
+    box.pack_start(grid, True, True, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>PID</b>")
+    lbl.set_property("halign", Gtk.Align.END)
+    grid.attach(lbl, 0, 0, 1, 1)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>Name</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    grid.attach(lbl, 2, 0, 1, 1)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>Kill</b>")
+    lbl.set_property("halign", Gtk.Align.START)
+    grid.attach(lbl, 3, 0, 1, 1)
+
+    idx = 1
+    for pid in processes:
+        if not tree.find_by_pid(pid):
+            lbl = Gtk.Label.new(str(pid))
+            lbl.set_property("halign", Gtk.Align.END)
+            grid.attach(lbl, 0, idx, 1, 1)
+
+            name = processes[pid]
+
+            if theme.lookup_icon(name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
+                img = Gtk.Image.new_from_icon_name(name, Gtk.IconSize.MENU)
+                img.set_property("halign", Gtk.Align.END)
+                grid.attach(img, 1, idx, 1, 1)
+
+            lbl = Gtk.Label.new(name)
+            lbl.set_property("halign", Gtk.Align.START)
+            grid.attach(lbl, 2, idx, 1, 1)
+
+
+
+            if processes[pid] not in protected:
+                btn = Gtk.Button.new_from_icon_name("gtk-close", Gtk.IconSize.MENU)
+                btn.connect("clicked", terminate, pid)
+                grid.attach(btn, 3, idx, 1, 1)
+
+            idx += 1
+    grid.show_all()
+    return True
+
+
+def main():
+    win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
+    win.connect('destroy', Gtk.main_quit)
+    win.connect("key-release-event", handle_keyboard)
+
+    box = Gtk.Box.new(Gtk.Orientation.VERTICAL, 0)
+    box.set_property("margin", 12)
+    win.add(box)
+
+    list_processes(box)
+
+    win.show_all()
+
+    GLib.timeout_add(1000, list_processes, box)
+    Gtk.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -10,9 +10,11 @@ from nwg_panel.tools import get_config_dir, load_json, save_json, check_key, epr
 
 common_settings = {}
 protected = ["systemd", "bash"]
+scrolled_window = None
 grid = Gtk.Grid()
 
 theme = Gtk.IconTheme.get_default()
+
 
 def handle_keyboard(win, event):
     if event.type == Gdk.EventType.KEY_RELEASE and event.keyval == Gdk.KEY_Escape:
@@ -24,13 +26,15 @@ def terminate(btn, pid):
     os.kill(pid, 2)
 
 
-def list_processes(widget, scrolled_window):
+def list_processes(widget):
     tree = Connection().get_tree()
     processes = {}
 
+    user = os.getenv('USER')
     for proc in psutil.process_iter(['pid', 'ppid', 'name', 'username']):
-        # if proc.info['username'] == os.getenv('USER') and proc.info['ppid'] == 1:
-        processes[proc.info['pid']] = proc.info['name']
+        if proc.info['username'] == os.getenv('USER') or not common_settings["processes-own-only"]:
+            # if proc.info['ppid'] == 1
+            processes[proc.info['pid']] = proc.info
 
     for child in scrolled_window.get_children():
         scrolled_window.remove(child)
@@ -40,60 +44,86 @@ def list_processes(widget, scrolled_window):
         grid.destroy()
 
     grid = Gtk.Grid.new()
-    grid.set_row_spacing(6)
+    grid.set_row_spacing(3)
+    grid.set_row_homogeneous(True)
     grid.set_column_spacing(6)
     scrolled_window.add(grid)
 
     lbl = Gtk.Label()
     lbl.set_markup("<b>PID</b>")
     lbl.set_property("halign", Gtk.Align.END)
-    grid.attach(lbl, 0, 0, 1, 1)
+    grid.attach(lbl, 1, 0, 1, 1)
 
     lbl = Gtk.Label()
-    lbl.set_markup("<b>User</b>")
+    lbl.set_markup("<b>Owner</b>")
     lbl.set_property("halign", Gtk.Align.END)
-    grid.attach(lbl, 1, 0, 1, 1)
+    grid.attach(lbl, 2, 0, 1, 1)
 
     lbl = Gtk.Label()
     lbl.set_markup("<b>Name</b>")
     lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 3, 0, 1, 1)
+    grid.attach(lbl, 4, 0, 1, 1)
 
     lbl = Gtk.Label()
-    lbl.set_markup("<b>Kill</b>")
+    lbl.set_markup("<b>Window</b>")
     lbl.set_property("halign", Gtk.Align.START)
-    grid.attach(lbl, 4, 0, 1, 1)
+    grid.attach(lbl, 5, 0, 1, 1)
 
     idx = 1
     for pid in processes:
-        if not tree.find_by_pid(pid) or common_settings["processes-background-only"]:
+        cons = tree.find_by_pid(pid)
+        if not cons or not common_settings["processes-background-only"]:
             lbl = Gtk.Label.new(str(pid))
             lbl.set_property("halign", Gtk.Align.END)
-            grid.attach(lbl, 0, idx, 1, 1)
+            grid.attach(lbl, 1, idx, 1, 1)
 
-            name = processes[pid]
+            lbl = Gtk.Label.new(processes[pid]["username"])
+            lbl.set_property("halign", Gtk.Align.END)
+            grid.attach(lbl, 2, idx, 1, 1)
 
+            name = processes[pid]["name"]
             if theme.lookup_icon(name, 16, Gtk.IconLookupFlags.FORCE_SYMBOLIC):
                 img = Gtk.Image.new_from_icon_name(name, Gtk.IconSize.MENU)
                 img.set_property("halign", Gtk.Align.END)
-                grid.attach(img, 2, idx, 1, 1)
+                grid.attach(img, 3, idx, 1, 1)
 
             lbl = Gtk.Label.new(name)
             lbl.set_property("halign", Gtk.Align.START)
-            grid.attach(lbl, 3, idx, 1, 1)
+            grid.attach(lbl, 4, idx, 1, 1)
 
-            if processes[pid] not in protected:
+            if processes[pid]["name"] not in protected and processes[pid]["username"] == user:
                 btn = Gtk.Button.new_from_icon_name("gtk-close", Gtk.IconSize.MENU)
                 btn.connect("clicked", terminate, pid)
-                grid.attach(btn, 4, idx, 1, 1)
+                grid.attach(btn, 0, idx, 1, 1)
+
+            win_name = ""
+            if cons:
+                if cons[0].app_id:
+                    win_name = cons[0].app_id
+                elif cons[0].window_class:
+                    win_name = cons[0].window_class
+                elif cons[0].window_title:
+                    win_name = cons[0].window_title
+
+            if win_name:
+                lbl = Gtk.Label.new(win_name)
+                lbl.set_property("halign", Gtk.Align.START)
+                grid.attach(lbl, 5, idx, 1, 1)
 
             idx += 1
-    grid.show_all()
+    scrolled_window.show_all()
+    scrolled_window.get_vadjustment().set_value(0)
     return True
 
 
 def on_background_cb(check_button):
     common_settings["processes-background-only"] = check_button.get_active()
+    list_processes(None)
+
+
+def on_own_cb(check_button):
+    common_settings["processes-own-only"] = check_button.get_active()
+    list_processes(None)
 
 
 def main():
@@ -116,6 +146,7 @@ def main():
     box.set_property("margin", 12)
     win.add(box)
 
+    global scrolled_window
     scrolled_window = Gtk.ScrolledWindow.new(None, None)
     scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.ALWAYS)
     scrolled_window.set_propagate_natural_width(True)
@@ -130,19 +161,24 @@ def main():
     cb.connect("toggled", on_background_cb)
     hbox.pack_start(cb, False, False, 6)
 
+    cb = Gtk.CheckButton.new_with_label("{}'s only".format(os.getenv('USER')))
+    cb.set_active(common_settings["processes-background-only"])
+    cb.connect("toggled", on_own_cb)
+    hbox.pack_start(cb, False, False, 6)
+
     btn = Gtk.Button.new_with_label("Close")
     hbox.pack_end(btn, False, False, 0)
     btn.connect("clicked", Gtk.main_quit)
 
     btn = Gtk.Button.new_with_label("Refresh")
     hbox.pack_end(btn, False, False, 0)
-    btn.connect("clicked", list_processes, scrolled_window)
-
-    list_processes(None, scrolled_window)
+    btn.connect("clicked", list_processes)
 
     win.show_all()
 
-    # GLib.timeout_add(1000, list_processes, scrolled_window)
+    list_processes(None)
+
+    # GLib.timeout_add(1000, list_processes, None, scrolled_window)
     Gtk.main()
 
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -22,7 +22,7 @@ scrolled_window = None
 grid = Gtk.Grid()
 window_lbl = None
 scroll = 0.0
-max_num_items = 0
+# max_num_items = 0
 
 theme = Gtk.IconTheme.get_default()
 
@@ -39,18 +39,13 @@ def terminate(btn, pid):
     except Exception as e:
         eprint(e)
 
+    list_processes(None)
+
 
 def on_scroll(s_window, event):
     adj = s_window.get_vadjustment()
     global scroll
     scroll = adj.get_value()
-
-
-def on_list_changed(s_window, rect):
-    s_window.show_all()
-    adj = s_window.get_vadjustment()
-    adj.set_value(scroll)
-    print("scroll:", scroll, "upper:", adj.get_upper(), "current:", adj.get_value())
 
 
 def list_processes(widget):
@@ -102,12 +97,17 @@ def list_processes(widget):
             lbl.set_xalign(0)
             grid.attach(lbl, 3, idx, 1, 1)
 
-            lbl = Gtk.Label.new("{}%".format(str(processes[pid]["cpu_percent"])))
+            percent = processes[pid]["cpu_percent"]
+            if percent == 0:
+                lbl = Gtk.Label.new("{}%".format(str(percent)))
+            else:
+                lbl = Gtk.Label()
+                lbl.set_markup("<b>{}</b>".format(str(percent)))
             lbl.set_width_chars(W_CPU)
             lbl.set_xalign(0)
             grid.attach(lbl, 4, idx, 1, 1)
 
-            lbl = Gtk.Label.new("{}%".format(str(round(processes[pid]["memory_percent"], 1))))
+            lbl = Gtk.Label.new("{}%".format(str(round(processes[pid]["memory_percent"], 2))))
             lbl.set_width_chars(W_MEM)
             lbl.set_xalign(0)
             grid.attach(lbl, 5, idx, 1, 1)
@@ -159,19 +159,19 @@ def list_processes(widget):
 
             idx += 1
 
-    global max_num_items
-    if max_num_items < idx:
-        max_num_items = idx
-
-    if idx < max_num_items:
-        for i in range(idx, max_num_items):
-            lbl = Gtk.Label()
-            lbl.set_markup("    ")
-            grid.attach(lbl, 0, i, 1, 1)
+    # global max_num_items
+    # if max_num_items < idx:
+    #     max_num_items = idx
+    #
+    # if idx < max_num_items:
+    #     for i in range(idx, max_num_items):
+    #         lbl = Gtk.Label()
+    #         lbl.set_markup("    ")
+    #         grid.attach(lbl, 0, i, 1, 1)
 
     grid.show_all()
 
-    scrolled_window.get_vadjustment().set_value(scroll)
+    # scrolled_window.get_vadjustment().set_value(scroll)
 
     return True
 
@@ -263,11 +263,9 @@ def main():
 
     global scrolled_window
     scrolled_window = Gtk.ScrolledWindow.new(None, None)
-    scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.ALWAYS)
-    scrolled_window.set_propagate_natural_width(True)
+    scrolled_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
     scrolled_window.set_propagate_natural_height(True)
-
-    scrolled_window.connect("scroll-event", on_scroll)
+    # scrolled_window.connect("scroll-event", on_scroll)
     box.pack_start(scrolled_window, True, True, 0)
 
     hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 12)

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -300,6 +300,8 @@ def main():
 
     win.show_all()
 
+    win.set_size_request(0, win.get_allocated_width() * 0.7)
+
     list_processes(None)
     Gdk.threads_add_timeout(GLib.PRIORITY_DEFAULT_IDLE, settings["processes-interval-ms"], list_processes, None)
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -151,27 +151,13 @@ def list_processes(widget):
 
             idx += 1
 
-    # global max_num_items
-    # if max_num_items < idx:
-    #     max_num_items = idx
-    #
-    # if idx < max_num_items:
-    #     for i in range(idx, max_num_items):
-    #         lbl = Gtk.Label()
-    #         lbl.set_markup("    ")
-    #         grid.attach(lbl, 0, i, 1, 1)
-
     grid.show_all()
-
-    # scrolled_window.get_vadjustment().set_value(scroll)
 
     return True
 
 
 def on_background_cb(check_button):
     common_settings["processes-background-only"] = check_button.get_active()
-    global max_num_items
-    max_num_items = 0
     if window_lbl:
         window_lbl.set_visible(not common_settings["processes-background-only"])
     list_processes(None)
@@ -179,8 +165,6 @@ def on_background_cb(check_button):
 
 def on_own_cb(check_button):
     common_settings["processes-own-only"] = check_button.get_active()
-    global max_num_items
-    max_num_items = 0
     list_processes(None)
 
 
@@ -265,8 +249,16 @@ def main():
     dist.set_property("vexpand", True)
     box.pack_start(dist, True, True, 0)
 
-    hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 12)
+    hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 6)
+    hbox.set_property("margin", 6)
     box.pack_start(hbox, False, False, 0)
+
+    img = Gtk.Image.new_from_icon_name("nwg-processes", Gtk.IconSize.LARGE_TOOLBAR)
+    hbox.pack_start(img, False, False, 0)
+
+    lbl = Gtk.Label()
+    lbl.set_markup("<b>nwg-processes</b>")
+    hbox.pack_start(lbl, False, False, 0)
 
     cb = Gtk.CheckButton.new_with_label("Background only")
     cb.set_tooltip_text("Processes that don't belong to the sway tree")
@@ -283,10 +275,6 @@ def main():
     btn = Gtk.Button.new_with_label("Close")
     hbox.pack_end(btn, False, False, 0)
     btn.connect("clicked", Gtk.main_quit)
-
-    # btn = Gtk.Button.new_with_label("Refresh")
-    # hbox.pack_end(btn, False, False, 0)
-    # btn.connect("clicked", list_processes)
 
     screen = Gdk.Screen.get_default()
     provider = Gtk.CssProvider()

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -325,7 +325,7 @@ def main():
 
     win.show_all()
 
-    win.set_size_request(0, win.get_allocated_width() * 0.7)
+    win.set_size_request(0, win.get_allocated_width() * 0.5)
 
     list_processes(None)
 

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -9,6 +9,8 @@ from gi.repository import Gtk, Gdk, GLib
 
 from nwg_panel.tools import get_config_dir, load_json, save_json, check_key, eprint
 
+sway = os.getenv('SWAYSOCK')
+
 W_PID = 10
 W_PPID = 10
 W_OWNER = 10
@@ -183,6 +185,8 @@ def main():
     }
     for key in defaults:
         check_key(settings, key, defaults[key])
+    if not sway:
+        settings["processes-background-only"] = False
     eprint("Common settings", settings)
 
     win = Gtk.Window.new(Gtk.WindowType.TOPLEVEL)
@@ -238,11 +242,12 @@ def main():
     lbl.set_xalign(0)
     desc_box.pack_start(lbl, True, True, 0)
 
-    global window_lbl
-    window_lbl = Gtk.Label.new("Window")
-    window_lbl.set_width_chars(W_WINDOW)
-    window_lbl.set_xalign(0)
-    desc_box.pack_start(window_lbl, True, True, 0)
+    if sway:
+        global window_lbl
+        window_lbl = Gtk.Label.new("Window")
+        window_lbl.set_width_chars(W_WINDOW)
+        window_lbl.set_xalign(0)
+        desc_box.pack_start(window_lbl, True, True, 0)
 
     global scrolled_window
     scrolled_window = Gtk.ScrolledWindow.new(None, None)
@@ -265,11 +270,12 @@ def main():
     lbl.set_markup("<b>nwg-processes</b>")
     hbox.pack_start(lbl, False, False, 0)
 
-    cb = Gtk.CheckButton.new_with_label("Background only")
-    cb.set_tooltip_text("Processes that don't belong to the sway tree")
-    cb.set_active(settings["processes-background-only"])
-    cb.connect("toggled", on_background_cb)
-    hbox.pack_start(cb, False, False, 6)
+    if sway:
+        cb = Gtk.CheckButton.new_with_label("Background only")
+        cb.set_tooltip_text("Processes that don't belong to the sway tree")
+        cb.set_active(settings["processes-background-only"])
+        cb.connect("toggled", on_background_cb)
+        hbox.pack_start(cb, False, False, 6)
 
     cb = Gtk.CheckButton.new_with_label("{}'s only".format(os.getenv('USER')))
     cb.set_tooltip_text("Processes that belong to the current $USER")

--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -95,8 +95,8 @@ def list_processes(widget):
             grid.attach(lbl, 2, idx, 1, 1)
 
             owner = processes[pid]["username"]
-            if len(owner) > W_OWNER:
-                owner = "{}…".format(owner[:W_OWNER - 1])
+            if len(owner) > W_OWNER - 1:
+                owner = "{}…".format(owner[:W_OWNER - 2])
             lbl = Gtk.Label.new(owner)
             lbl.set_width_chars(W_OWNER)
             lbl.set_xalign(0)
@@ -142,8 +142,8 @@ def list_processes(widget):
                 img.set_property("halign", Gtk.Align.END)
                 grid.attach(img, 6, idx, 1, 1)
 
-            if len(name) > W_NAME:
-                name = "{}…".format(name[:W_NAME - 1])
+            if len(name) > W_NAME - 1:
+                name = "{}…".format(name[:W_NAME - 2])
             lbl = Gtk.Label.new(name)
             lbl.set_width_chars(W_NAME)
             lbl.set_xalign(0)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.7.16',
+    version='0.7.17',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,
@@ -25,7 +25,8 @@ setup(
         'gui_scripts': [
             'nwg-panel = nwg_panel.main:main',
             'nwg-panel-config = nwg_panel.config:main',
-            'nwg-dwl-interface = nwg_panel.dwl_interface:main'
+            'nwg-dwl-interface = nwg_panel.dwl_interface:main',
+            'nwg-processes = nwg_panel.processes:main'
         ]
     }
 )


### PR DESCRIPTION
- added the **nwg-processes command**, as the nwg-panel new entry point. It provides a simple processes browser, with a possibility to watch CPU & memory usage, and a button to kill a process. The 'Background only' check button allows to filter out processes that have a window (belong to the sway tree). The '$USER's only' check button determines if to show the current user's processes, or all of them.

![image](https://user-images.githubusercontent.com/20579136/219951247-9fd1115d-4c8f-499e-9332-f07d04123ef7.png)

You can customize processes polling rate (higher values for slower machines) in the panel Common settings:

![image](https://user-images.githubusercontent.com/20579136/219951661-d45fd725-ffc4-4685-a806-f979a6d87b2e.png)

- added **Battery low notification**. You can customize the battery critical level and the notification frequency in the Panel -> Controls settings:

![image](https://user-images.githubusercontent.com/20579136/219951463-8ef2b69f-5ac4-4f0b-b446-ded72d63d28e.png)

Closes #180.