### PR TITLE
Fix tray pixmaps

### DIFF
--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -143,7 +143,7 @@ class Tray(Gtk.EventBox):
 
             if "IconName" in item.properties:
                 update_icon(image, item, self.icon_size, self.icons_path)
-            elif "IconPixmap" in item.properties:
+            elif "IconPixmap" in item.properties and len(item.properties["IconPixmap"]) != 0:
                 update_icon_from_pixmap(image, item, self.icon_size)
 
             if "Tooltip" in item.properties:
@@ -179,7 +179,7 @@ class Tray(Gtk.EventBox):
 
         if "IconThemePath" in changed_properties or "IconName" in changed_properties:
             update_icon(image, item, self.icon_size, self.icons_path)
-        elif "IconPixmap" in changed_properties:
+        elif "IconPixmap" in changed_properties and len(item.properties["IconPixmap"]) != 0:
             update_icon_from_pixmap(image, item, self.icon_size)
             pass
 

--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -141,10 +141,10 @@ class Tray(Gtk.EventBox):
             event_box = Gtk.EventBox()
             image = Gtk.Image()
 
-            if "IconPixmap" in item.properties:
-                update_icon_from_pixmap(image, item, self.icon_size)
-            elif "IconName" in item.properties:
+            if "IconName" in item.properties:
                 update_icon(image, item, self.icon_size, self.icons_path)
+            elif "IconPixmap" in item.properties:
+                update_icon_from_pixmap(image, item, self.icon_size)
 
             if "Tooltip" in item.properties:
                 update_tooltip(image, item)
@@ -177,11 +177,11 @@ class Tray(Gtk.EventBox):
         event_box = self.items[full_service_name]["event_box"]
         image = self.items[full_service_name]["image"]
 
-        if "IconPixmap" in changed_properties:
+        if "IconThemePath" in changed_properties or "IconName" in changed_properties:
+            update_icon(image, item, self.icon_size, self.icons_path)
+        elif "IconPixmap" in changed_properties:
             update_icon_from_pixmap(image, item, self.icon_size)
             pass
-        elif "IconThemePath" in changed_properties or "IconName" in changed_properties:
-            update_icon(image, item, self.icon_size, self.icons_path)
 
         if "Tooltip" in changed_properties:
             update_tooltip(image, item)


### PR DESCRIPTION
During research of issue #157, it was found that the IconPixmap provided by fcitx was empty.   https://github.com/fcitx/fcitx5/blob/master/src/modules/notificationitem/notificationitem.cpp#L158
However, this is not a bug in fcitx. In the specification, The pixmap is provided as a fallback. 
https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/  
The icon should be loaded from the IconName before attempting to load the pixmap.