### PR TITLE
Enable pango markup for sway workspace labels

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -1909,18 +1909,12 @@ class EditorWrapper(object):
         self.ws_custom_labels = builder.get_object("custom-labels")
         self.ws_custom_labels.set_tooltip_text(voc["custom-labels-tooltip"])
         labels = settings["custom-labels"]
-        text = ""
-        for item in labels:
-            text += str(item) + " "
-        self.ws_custom_labels.set_text(text.strip())
+        self.ws_custom_labels.get_buffer().set_text('\n'.join(labels))
 
         self.ws_focused_labels = builder.get_object("focused-labels")
         self.ws_focused_labels.set_tooltip_text(voc["custom-labels-tooltip"])
         labels = settings["focused-labels"]
-        text = ""
-        for item in labels:
-            text += str(item) + " "
-        self.ws_focused_labels.set_text(text.strip())
+        self.ws_focused_labels.get_buffer().set_text('\n'.join(labels))
 
         self.ws_show_icon = builder.get_object("show-icon")
         self.ws_show_icon.set_label(voc["show-focused-window-icon"])
@@ -1969,11 +1963,13 @@ class EditorWrapper(object):
         if val:
             settings["numbers"] = val.split()
 
-        val = self.ws_custom_labels.get_text()
-        settings["custom-labels"] = val.split()
+        buffer = self.ws_custom_labels.get_buffer()
+        val = buffer.get_text(*buffer.get_bounds(), False)
+        settings["custom-labels"] = val.splitlines()
 
-        val = self.ws_focused_labels.get_text()
-        settings["focused-labels"] = val.split()
+        buffer = self.ws_focused_labels.get_buffer()
+        val = buffer.get_text(*buffer.get_bounds(), False)
+        settings["focused-labels"] = val.splitlines()
 
         val = self.ws_show_icon.get_active()
         if val is not None:

--- a/nwg_panel/glade/config_sway_workspaces.glade
+++ b/nwg_panel/glade/config_sway_workspaces.glade
@@ -206,9 +206,19 @@
           </packing>
         </child>
         <child>
-          <object class="GtkEntry" id="custom-labels">
+          <object class="GtkScrolledWindow">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
+            <property name="propagate-natural-width">True</property>
+            <property name="propagate-natural-height">True</property>
+            <child>
+              <object class="GtkTextView" id="custom-labels">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="monospace">True</property>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="left-attach">1</property>
@@ -216,9 +226,19 @@
           </packing>
         </child>
         <child>
-          <object class="GtkEntry" id="focused-labels">
+          <object class="GtkScrolledWindow">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
+            <property name="propagate-natural-width">True</property>
+            <property name="propagate-natural-height">True</property>
+            <child>
+              <object class="GtkTextView" id="focused-labels">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="monospace">True</property>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="left-attach">1</property>

--- a/nwg_panel/modules/sway_workspaces.py
+++ b/nwg_panel/modules/sway_workspaces.py
@@ -43,12 +43,12 @@ class SwayWorkspaces(Gtk.Box):
         ws_num = -1
         if self.i3.get_tree().find_focused():
             ws_num, win_name, win_id, non_empty, win_layout, numbers = self.find_details()
-        
+
         if len(self.settings["custom-labels"]) == 1:
             self.settings["custom-labels"] *= len(self.settings["numbers"])
         elif len(self.settings["custom-labels"]) != len(self.settings["numbers"]):
             self.settings["custom-labels"] = []
-        
+
         if len(self.settings["focused-labels"]) == 1:
             self.settings["focused-labels"] *= len(self.settings["numbers"])
         elif len(self.settings["focused-labels"]) != len(self.settings["numbers"]):
@@ -103,6 +103,7 @@ class SwayWorkspaces(Gtk.Box):
             lbl = Gtk.Label("{}{}".format(autotiling, label))
         else:
             lbl = Gtk.Label("{}".format(label))
+        lbl.set_use_markup(True)
         if self.settings["angle"] != 0.0:
             lbl.set_angle(self.settings["angle"])
             self.name_label.set_angle(self.settings["angle"])
@@ -163,8 +164,8 @@ class SwayWorkspaces(Gtk.Box):
                         else:
                             if text.endswith("."):
                                 text = text[0:-1]
-                    
-                    lbl.set_text(text)
+
+                    lbl.set_markup(text)
 
                     if num == str(ws_num):
                         self.ws_num2box[num].set_property("name", "task-box-focused")


### PR DESCRIPTION
This allows using pango markups for labels, which enables fine-grained controls and is also supported by waybar.

Example:
```json
"custom-labels": [
  "1 <span font='Font Awesome 6 Free 10'>\uf120</span>",
  "2 <span font='Font Awesome 6 Brands 10'>\uf269</span>",
  "3 <span font='Font Awesome 6 Free 10'>\uf121</span>",
  "4 <span font='Font Awesome 6 Free 10'>\uf07b</span>",
  "5 <span font='Font Awesome 6 Brands 10'>\ue3d9</span>",
  "6 <span font='Font Awesome 6 Free 10'>\uf1c2</span>",
  "7 <span font='Font Awesome 6 Free 10'>\uf075</span>",
  "8 <span font='Font Awesome 6 Free 10'>\uf0e0</span>"
],
```
![demo](https://user-images.githubusercontent.com/5774651/233376160-64720a6e-6f94-454f-9217-9a61526c1cff.png)
