### PR TITLE
Properly arrange the alpha channel for IconPixmap

### DIFF
--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -56,8 +56,14 @@ def update_icon_from_pixmap(image, item, icon_size):
             largest_data = data
             largest_width = width
             largest_height = height
-    pixbuf = GdkPixbuf.Pixbuf.new_from_bytes(
-        GLib.Bytes().new(largest_data),
+
+    # ARGB -> RGBA
+    rgba_data = []
+    for i in range(0, len(largest_data), 4):
+        rgba_data += largest_data[i + 1:i + 4] + [largest_data[i]]
+
+    pixbuf = GdkPixbuf.Pixbuf.new_from_data(
+        rgba_data,
         GdkPixbuf.Colorspace.RGB,
         True,
         8,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5774651/234585968-eaa2c102-54d9-49ff-bd4f-cd25b200826d.png)

After:
![image](https://user-images.githubusercontent.com/5774651/234585851-70124e77-7988-4492-9d79-2b856ef67ce5.png)
