### PR TITLE
Optimize Hyprland watcher

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -150,6 +150,7 @@ SKELETON_PANEL: dict = {
         "mark-content": True,
         "show-names": True,
         "mark-floating": True,
+        "mark-xwayland": True,
         "angle": 0.0
     },
     "clock": {
@@ -2034,6 +2035,7 @@ class EditorWrapper(object):
             "mark-content": True,
             "show-names": True,
             "mark-floating": True,
+            "mark-xwayland": True,
             "angle": 0.0
         }
         for key in defaults:
@@ -2092,6 +2094,9 @@ class EditorWrapper(object):
         self.ws_mark_floating = builder.get_object("mark-floating")
         self.ws_mark_floating.set_active(settings["mark-floating"])
 
+        self.ws_mark_xwayland = builder.get_object("mark-xwayland")
+        self.ws_mark_xwayland.set_active(settings["mark-xwayland"])
+
         self.ws_angle = builder.get_object("angle")
         self.ws_angle.set_tooltip_text(voc["angle-tooltip"])
         self.ws_angle.set_active_id(str(settings["angle"]))
@@ -2112,6 +2117,7 @@ class EditorWrapper(object):
         settings["mark-content"] = self.ws_mark_content.get_active()
         settings["show-names"] = self.ws_show_names.get_active()
         settings["mark-floating"] = self.ws_mark_floating.get_active()
+        settings["mark-xwayland"] = self.ws_mark_xwayland.get_active()
         try:
             settings["angle"] = float(self.ws_angle.get_active_id())
         except:

--- a/nwg_panel/glade/config_hyprland_workspaces.glade
+++ b/nwg_panel/glade/config_hyprland_workspaces.glade
@@ -8,7 +8,7 @@
     <property name="label-xalign">0.5</property>
     <property name="shadow-type">out</property>
     <child>
-      <!-- n-columns=3 n-rows=8 -->
+      <!-- n-columns=3 n-rows=9 -->
       <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -131,33 +131,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkComboBoxText" id="angle">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <items>
-              <item id="0.0" translatable="yes">0°</item>
-              <item id="90.0" translatable="yes">90°</item>
-              <item id="270.0" translatable="yes">270°</item>
-            </items>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">7</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-angle">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Angle:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">7</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkSpinButton" id="num-workspaces">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
@@ -193,6 +166,53 @@
             <property name="left-attach">1</property>
             <property name="top-attach">6</property>
           </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="angle">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <items>
+              <item id="0.0" translatable="yes">0°</item>
+              <item id="90.0" translatable="yes">90°</item>
+              <item id="270.0" translatable="yes">270°</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-angle">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Angle:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="mark-xwayland">
+            <property name="label" translatable="yes">Mark Xwayland</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="halign">start</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">7</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -86,6 +86,7 @@ if his:
     from nwg_panel.modules.hyprland_workspaces import HyprlandWorkspaces
 hypr_watcher_started = False
 last_client_addr = ""
+last_client_details = ""
 
 common_settings = {}
 restart_cmd = ""
@@ -149,27 +150,30 @@ def hypr_watcher():
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     client.connect("/tmp/hypr/{}/.socket2.sock".format(his))
 
+    global last_client_addr, last_client_details
+    client_addr, client_details = None, None
+
     while True:
         datagram = client.recv(2048)
         e_full_string = datagram.decode('utf-8').strip()
         # eprint("Event: {}".format(e_full_string))
 
-        global last_client_addr
-        client_addr, client_details = None, None
+        refreshed = False
 
         # remember client address (string) for further event filtering
-        if "activewindowv2" in e_full_string:
+        if "activewindowv2" in e_full_string or "activewindow>>" in e_full_string:
             lines = e_full_string.splitlines()
             for line in lines:
                 if line.startswith("activewindowv2"):
-                    client_addr = e_full_string.split("activewindowv2>>")[1].strip().split()[0]
-
-        # remember client details (string) for further event filtering
-        if "activewindow>>" in e_full_string:
-            lines = e_full_string.splitlines()
-            for line in lines:
-                if line.startswith("activewindow>>"):
-                    client_details = e_full_string.split("activewindow>>")[1].strip()
+                    try:
+                        s = e_full_string.split(">>")[1].strip()
+                        ca = int(s, 16)
+                        client_addr = s
+                        break
+                    except ValueError:
+                        continue
+                elif line.startswith("activewindow>>"):
+                    client_details = line.split(">>")[1]
 
         event_name = e_full_string.split(">>")[0]
 
@@ -177,29 +181,32 @@ def hypr_watcher():
             for item in common.h_taskbars_list:
                 GLib.timeout_add(0, item.list_monitors)
 
-        if event_name == "changefloatingmode":
+        if event_name == "activewindowv2" and client_addr != last_client_addr:
             for item in common.h_taskbars_list:
                 GLib.timeout_add(0, item.refresh)
 
-        if event_name in ["closewindow"]:
-            # skip client details if previously used
-            # if client_details != last_client_details:
+            for item in common.workspaces_list:
+                GLib.timeout_add(0, item.refresh)
+
+            last_client_addr = client_addr
+            refreshed = True
+
+        if not refreshed and event_name == "activewindow" and client_details != last_client_details:
             for item in common.h_taskbars_list:
                 GLib.timeout_add(0, item.refresh)
 
-        if event_name in ["activewindowv2", "activewindow"]:
-            # skip window address if previously used
-            if client_addr and client_addr != last_client_addr:  # filter out consecutive events from the same client
-                for item in common.h_taskbars_list:
-                    GLib.timeout_add(0, item.refresh)
-                last_client_addr = client_addr
+            for item in common.workspaces_list:
+                GLib.timeout_add(0, item.refresh)
 
-        # refresh HyprlandWorkspaces
-        if len(common.workspaces_list) > 0 and event_name in ["activewindowv2", "activewindow", "changefloatingmode"] and len(common.workspaces_list) > 0:
-            if client_addr and client_addr != last_client_addr:
-                last_client_addr = client_addr
-                for item in common.workspaces_list:
-                    GLib.timeout_add(0, item.refresh)
+            last_client_details = client_details
+            refreshed = True
+
+        if not refreshed and event_name in ["changefloatingmode", "closewindow"]:
+            for item in common.h_taskbars_list:
+                GLib.timeout_add(0, item.refresh)
+
+            for item in common.workspaces_list:
+                GLib.timeout_add(0, item.refresh)
 
 
 def check_tree():

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -86,8 +86,6 @@ if his:
     from nwg_panel.modules.hyprland_workspaces import HyprlandWorkspaces
 hypr_watcher_started = False
 last_client_addr = ""
-last_client_details = ""
-buildbox_fired = False
 
 common_settings = {}
 restart_cmd = ""
@@ -156,7 +154,7 @@ def hypr_watcher():
         e_full_string = datagram.decode('utf-8').strip()
         # eprint("Event: {}".format(e_full_string))
 
-        global last_client_addr, last_client_details
+        global last_client_addr
         client_addr, client_details = None, None
 
         # remember client address (string) for further event filtering
@@ -179,29 +177,22 @@ def hypr_watcher():
             for item in common.h_taskbars_list:
                 GLib.timeout_add(0, item.list_monitors)
 
-        global buildbox_fired
-
         if event_name == "changefloatingmode":
             for item in common.h_taskbars_list:
                 GLib.timeout_add(0, item.refresh)
-            last_client_details = client_details
-            buildbox_fired = True  # skip 'activewindowv2' check
 
         if event_name in ["closewindow"]:
             # skip client details if previously used
-            if client_details != last_client_details:
-                for item in common.h_taskbars_list:
-                    GLib.timeout_add(0, item.refresh)
-                last_client_details = client_details
-                buildbox_fired = True  # skip 'activewindowv2' check
+            # if client_details != last_client_details:
+            for item in common.h_taskbars_list:
+                GLib.timeout_add(0, item.refresh)
 
-        if not buildbox_fired and event_name in ["activewindowv2"]:
+        if event_name in ["activewindowv2", "activewindow"]:
             # skip window address if previously used
             if client_addr and client_addr != last_client_addr:  # filter out consecutive events from the same client
                 for item in common.h_taskbars_list:
                     GLib.timeout_add(0, item.refresh)
                 last_client_addr = client_addr
-            buildbox_fired = False  # clear for next iteration
 
         # refresh HyprlandWorkspaces
         if len(common.workspaces_list) > 0 and event_name in ["activewindowv2", "activewindow", "changefloatingmode"] and len(common.workspaces_list) > 0:

--- a/nwg_panel/modules/hyprland_taskbar.py
+++ b/nwg_panel/modules/hyprland_taskbar.py
@@ -75,6 +75,7 @@ class HyprlandTaskbar(Gtk.Box):
         self.activewindow = json.loads(output)
 
     def refresh(self):
+        print("Taskbar refresh")
         self.list_monitors()
         self.list_workspaces()
         self.list_clients()

--- a/nwg_panel/modules/hyprland_taskbar.py
+++ b/nwg_panel/modules/hyprland_taskbar.py
@@ -75,7 +75,6 @@ class HyprlandTaskbar(Gtk.Box):
         self.activewindow = json.loads(output)
 
     def refresh(self):
-        print("Taskbar refresh")
         self.list_monitors()
         self.list_workspaces()
         self.list_clients()

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -34,6 +34,7 @@ class HyprlandWorkspaces(Gtk.Box):
         check_key(self.settings, "mark-content", True)
         check_key(self.settings, "show-names", True)
         check_key(self.settings, "mark-floating", True)
+        check_key(self.settings, "mark-xwayland", True)
         check_key(self.settings, "angle", 0.0)
 
         if self.settings["angle"] != 0.0:
@@ -116,6 +117,8 @@ class HyprlandWorkspaces(Gtk.Box):
         if active_window:
             client_class = active_window["class"]
             client_title = active_window["title"][:self.settings["name-length"]]
+            if self.settings["mark-xwayland"] and active_window["xwayland"]:
+                client_title = "X|{}".format(client_title)
             floating = active_window["floating"]
         else:
             client_class = ""

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.8.5',
+    version='0.8.6',
     description='GTK3-based panel for sway window manager',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- logic altered in order not to trigger refresh on consecutive events from the very same window (especially PITA over GtkListView);
- HyprlandWorkspaces: added a switch to turn on/of the Xwayland marker in the active window name.