### PR TITLE
Have one background thread running forever for periodic tasks

### DIFF
--- a/nwg_panel/modules/cpu_avg.py
+++ b/nwg_panel/modules/cpu_avg.py
@@ -2,10 +2,11 @@
 
 from gi.repository import GLib
 
-import threading
 import psutil
 
 import gi
+
+from nwg_panel.tools import create_background_task
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
@@ -24,8 +25,7 @@ class CpuAvg(Gtk.EventBox):
         self.label.set_property("name", "executor-label")
 
         self.build_box()
-
-        Gdk.threads_add_timeout_seconds(GLib.PRIORITY_LOW, 2, self.refresh)
+        self.refresh()
 
     def update_widget(self, val, cnt):
         self.label.set_text(val)
@@ -44,10 +44,8 @@ class CpuAvg(Gtk.EventBox):
             print(e)
 
     def refresh(self):
-        thread = threading.Thread(target=self.get_output)
-        thread.daemon = True
+        thread = create_background_task(self.get_output, 2)
         thread.start()
-        return True
 
     def build_box(self):
         self.box.pack_start(self.label, False, False, 4)

--- a/nwg_panel/modules/executor.py
+++ b/nwg_panel/modules/executor.py
@@ -2,13 +2,12 @@
 
 import os
 import subprocess
-import threading
 import signal
 
 import gi
 from gi.repository import GLib
 
-from nwg_panel.tools import check_key, update_image
+from nwg_panel.tools import check_key, update_image, create_background_task
 
 gi.require_version('Gtk', '3.0')
 gi.require_version('Gdk', '3.0')
@@ -78,9 +77,6 @@ class Executor(Gtk.EventBox):
         self.build_box()
         self.refresh()
 
-        if settings["interval"] > 0:
-            Gdk.threads_add_timeout_seconds(GLib.PRIORITY_LOW, settings["interval"], self.refresh)
-
     def update_widget(self, output):
         # parse output
         label = new_path = None
@@ -136,10 +132,8 @@ class Executor(Gtk.EventBox):
                 print(e)
 
     def refresh(self):
-        thread = threading.Thread(target=self.get_output)
-        thread.daemon = True
+        thread = create_background_task(self.get_output, self.settings["interval"])
         thread.start()
-        return True
 
     def build_box(self):
         if self.settings["icon-placement"] == "left":

--- a/nwg_panel/modules/swaync.py
+++ b/nwg_panel/modules/swaync.py
@@ -3,9 +3,8 @@
 from gi.repository import GLib
 
 import subprocess
-import threading
 
-from nwg_panel.tools import check_key, update_image
+from nwg_panel.tools import check_key, update_image, create_background_task
 
 import gi
 
@@ -65,9 +64,6 @@ class SwayNC(Gtk.EventBox):
         self.build_box()
         self.refresh()
 
-        if settings["interval"] > 0:
-            Gdk.threads_add_timeout_seconds(GLib.PRIORITY_LOW, settings["interval"], self.refresh)
-
     def update_widget(self, output):
         if output:
             try:
@@ -100,10 +96,8 @@ class SwayNC(Gtk.EventBox):
             print(e)
 
     def refresh(self):
-        thread = threading.Thread(target=self.get_output)
-        thread.daemon = True
+        thread = create_background_task(self.get_output, self.settings["interval"])
         thread.start()
-        return True
 
     def build_box(self):
         if self.settings["icon-placement"] == "left":

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -516,23 +516,23 @@ def set_brightness(percent, device="", controller=""):
         percent = 1
     if nwg_panel.common.commands["light"] and controller == "light":
         if device:
-            subprocess.call("light -s {} -S {}".format(device, percent).split())
+            subprocess.Popen("light -s {} -S {}".format(device, percent).split())
         else:
-            subprocess.call("light -S {}".format(percent).split())
+            subprocess.Popen("light -S {}".format(percent).split())
     elif nwg_panel.common.commands["brightnessctl"] and controller == "brightnessctl":
         if device:
-            subprocess.call("brightnessctl -d {} s {}%".format(device, percent).split(),
-                            stdout=subprocess.DEVNULL,
-                            stderr=subprocess.STDOUT)
+            subprocess.Popen("brightnessctl -d {} s {}%".format(device, percent).split(),
+                             stdout=subprocess.DEVNULL,
+                             stderr=subprocess.STDOUT)
         else:
-            subprocess.call("brightnessctl s {}%".format(percent).split(),
-                            stdout=subprocess.DEVNULL,
-                            stderr=subprocess.STDOUT)
+            subprocess.Popen("brightnessctl s {}%".format(percent).split(),
+                             stdout=subprocess.DEVNULL,
+                             stderr=subprocess.STDOUT)
     elif nwg_panel.common.commands["ddcutil"] and controller == "ddcutil":
         if device:
-            subprocess.call("ddcutil setvcp 10 {} --bus={}".format(percent, device).split())
+            subprocess.Popen("ddcutil setvcp 10 {} --bus={}".format(percent, device).split())
         else:
-            subprocess.call("ddcutil setvcp 10 {}".format(percent).split())
+            subprocess.Popen("ddcutil setvcp 10 {}".format(percent).split())
     else:
         eprint("Either 'light' or 'brightnessctl' or 'ddcutil' package required")
 

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -7,6 +7,7 @@ import subprocess
 import stat
 import time
 import socket
+import threading
 
 import gi
 
@@ -396,6 +397,22 @@ def check_commands():
         nwg_panel.common.commands["python-requests"] = True
     except ModuleNotFoundError:
         pass
+
+
+def create_background_task(target, interval, args=(), kwargs=None):
+    if kwargs is None:
+        kwargs = {}
+
+    def loop_wrapper():
+        if interval > 0:
+            while True:
+                target(*args, **kwargs)
+                time.sleep(interval)
+        else:
+            target(*args, **kwargs)
+
+    thread = threading.Thread(target=loop_wrapper, daemon=True)
+    return thread
 
 
 def get_volume():


### PR DESCRIPTION
While this change seems trivial, it largely improves the overall fluency, e.g., scrolling the openweathermap widget no longer lags.