### PR TITLE
fix misbehaving keyboard interactivity

### DIFF
--- a/nwg_panel/modules/clock.py
+++ b/nwg_panel/modules/clock.py
@@ -172,6 +172,7 @@ class Clock(Gtk.EventBox):
         GtkLayerShell.init_for_window(self.popup)
         GtkLayerShell.set_layer(self.popup, GtkLayerShell.Layer.TOP)
         GtkLayerShell.set_keyboard_interactivity(self.popup, True)
+        GtkLayerShell.set_keyboard_mode(self.popup, GtkLayerShell.KeyboardMode.NONE)
 
         if self.settings["calendar-placement"] in ["top-left", "top", "top-right"]:
             GtkLayerShell.set_anchor(self.popup, GtkLayerShell.Edge.TOP, 1)


### PR DESCRIPTION
Allow closing the calendar window by clicking the Clock label on Hyprland. Required setting the layer shell keyboard mode `GtkLayerShell.KeyboardMode.NONE` (which should be set by default).