### PR TITLE
check item_proxy attribute before calling - sni_system_tray

### DIFF
--- a/nwg_panel/modules/sni_system_tray/item.py
+++ b/nwg_panel/modules/sni_system_tray/item.py
@@ -57,25 +57,30 @@ class StatusNotifierItem(object):
 
     def item_available_handler(self, _observer):
         self.item_proxy = self.session_bus.get_proxy(self.service_name, self.object_path)
-        self.item_proxy.PropertiesChanged.connect(
-            lambda _if, changed, invalid: self.change_handler(list(changed), invalid)
-        )
-        self.item_proxy.NewTitle.connect(
-            lambda: self.change_handler(["Title"])
-        )
-        self.item_proxy.NewIcon.connect(
-            lambda: self.change_handler(["IconName", "IconPixmap"])
-        )
-        self.item_proxy.NewAttentionIcon.connect(
-            lambda: self.change_handler(["AttentionIconName", "AttentionIconPixmap"])
-        )
+        if hasattr(self.item_proxy, "PropertiesChanged"):
+            self.item_proxy.PropertiesChanged.connect(
+                lambda _if, changed, invalid: self.change_handler(list(changed), invalid)
+            )
+        if hasattr(self.item_proxy, 'NewTitle'):
+            self.item_proxy.NewTitle.connect(
+                lambda: self.change_handler(["Title"])
+            )
+        if hasattr(self.item_proxy, 'NewIcon'):
+            self.item_proxy.NewIcon.connect(
+                lambda: self.change_handler(["IconName", "IconPixmap"])
+            )
+        if hasattr(self.item_proxy, 'NewAttentionIcon'):
+            self.item_proxy.NewAttentionIcon.connect(
+                lambda: self.change_handler(["AttentionIconName", "AttentionIconPixmap"])
+            )
         if hasattr(self.item_proxy, "NewIconThemePath"):
             self.item_proxy.NewIconThemePath.connect(
                 lambda _icon_theme_path: self.change_handler(["IconThemePath"])
             )
-        self.item_proxy.NewStatus.connect(
-            lambda _status: self.change_handler(["Status"])
-        )
+        if hasattr(self.item_proxy, "NewStatus"):
+            self.item_proxy.NewStatus.connect(
+                lambda _status: self.change_handler(["Status"])
+            )
         for name in PROPERTIES:
             try:
                 self.properties[name] = getattr(self.item_proxy, name)


### PR DESCRIPTION
not sure why this happens. But it was preventing my tray to load. Added some checks so that it can have a safe fallback and not break if this item_proxy doesn't have these attributes.

related to #224 

![image](https://github.com/nwg-piotr/nwg-panel/assets/29256024/6b362af2-a316-472d-8ffb-26f7f264c20b)
