### PR TITLE
RT signals to hide/show panels

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -864,7 +864,9 @@ class EditorWrapper(object):
             "icons": "",
             "css-name": "",
             "homogeneous": True,
-            "exclusive-zone": True
+            "exclusive-zone": True,
+            "sigrt": signal.SIGRTMAX,
+            "use-sigrt": False
         }
         for key in defaults:
             check_key(self.panel, key, defaults[key])
@@ -894,6 +896,7 @@ class EditorWrapper(object):
         builder.get_object("lbl-spacing").set_text("{}:".format(voc["spacing"]))
         builder.get_object("lbl-icon-set").set_text("{}:".format(voc["icon-set"]))
         builder.get_object("lbl-css-name").set_text("{}:".format(voc["css-name"]))
+        builder.get_object("lbl-hide-show-signal").set_text("{}: ".format(voc["hide-show-signal"]))
 
         cb = builder.get_object("homogeneous")
         cb.set_label(voc["homogeneous"])
@@ -1017,6 +1020,18 @@ class EditorWrapper(object):
         self.eb_css_name = builder.get_object("css-name")
         self.eb_css_name.set_text(self.panel["css-name"])
 
+        self.panel_sigrt = builder.get_object("sigrt")
+        self.panel_sigrt.set_tooltip_text(voc["hide-show-signal-tooltip"])
+        self.panel_sigrt.set_numeric(True)
+        adj = Gtk.Adjustment(value=0, lower=signal.SIGRTMIN, upper=signal.SIGRTMAX + 1, step_increment=1,
+                             page_increment=1, page_size=1)
+        self.panel_sigrt.configure(adj, 1, 0)
+        self.panel_sigrt.set_value(self.panel["sigrt"])
+
+        self.panel_use_sigrt = builder.get_object("use-sigrt")
+        self.panel_use_sigrt.set_label(voc["use-signal"])
+        self.panel_use_sigrt.set_active(self.panel["use-sigrt"])
+
         self.cb_homogeneous = builder.get_object("homogeneous")
         self.cb_homogeneous.set_active(self.panel["homogeneous"])
 
@@ -1107,6 +1122,9 @@ class EditorWrapper(object):
 
         val = self.eb_css_name.get_text()
         self.panel["css-name"] = val
+
+        self.panel["sigrt"] = int(self.panel_sigrt.get_value())
+        self.panel["use-sigrt"] = self.panel_use_sigrt.get_active()
 
         self.panel["homogeneous"] = self.cb_homogeneous.get_active()
 

--- a/nwg_panel/glade/config_executor.glade
+++ b/nwg_panel/glade/config_executor.glade
@@ -373,19 +373,6 @@ executor will create a new one.</property>
           </packing>
         </child>
         <child>
-          <object class="GtkCheckButton" id="use-sigrt">
-            <property name="label" translatable="yes">use signal</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">15</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkLabel" id="lbl-refresh-on-signal">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -434,6 +421,19 @@ executor will create a new one.</property>
           <packing>
             <property name="left-attach">1</property>
             <property name="top-attach">15</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="use-sigrt">
+            <property name="label" translatable="yes">use signal</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">14</property>
           </packing>
         </child>
         <child>

--- a/nwg_panel/glade/config_panel.glade
+++ b/nwg_panel/glade/config_panel.glade
@@ -8,7 +8,7 @@
     <property name="label-xalign">0.5</property>
     <property name="shadow-type">out</property>
     <child>
-      <!-- n-columns=2 n-rows=16 -->
+      <!-- n-columns=3 n-rows=17 -->
       <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -338,42 +338,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <child>
-              <object class="GtkSpinButton" id="width">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="width-chars">4</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="width-auto">
-                <property name="label" translatable="yes">auto</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="draw-indicator">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">6</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkLabel" id="lbl-menu-start">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -423,7 +387,7 @@
           </object>
           <packing>
             <property name="left-attach">1</property>
-            <property name="top-attach">15</property>
+            <property name="top-attach">16</property>
           </packing>
         </child>
         <child>
@@ -437,8 +401,111 @@
           </object>
           <packing>
             <property name="left-attach">0</property>
+            <property name="top-attach">16</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-hide-show-signal">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Hide/show signal:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
             <property name="top-attach">15</property>
           </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="width-auto">
+            <property name="label" translatable="yes">auto</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="width">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">4</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="sigrt">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">15</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="use-sigrt">
+            <property name="label" translatable="yes">use signal</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">15</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
       </object>
     </child>

--- a/nwg_panel/langs/en_US.json
+++ b/nwg_panel/langs/en_US.json
@@ -81,6 +81,8 @@
   "header-icon-size": "Header icon size",
   "height": "Height",
   "hide-empty-ws": "Hide empty workspaces",
+  "hide-show-signal": "Hide/show signal",
+  "hide-show-signal-tooltip": "Hide/show panel on an RT signal. Use `pkill -f -<signal_number> nwg-panel` in a key binding.",
   "homogeneous": "Homogeneous",
   "homogeneous-tooltip": "Sets equal columns width be default if 'Modules center' not empty.",
   "horizontal-padding": "Horizontal padding",

--- a/nwg_panel/langs/pl_PL.json
+++ b/nwg_panel/langs/pl_PL.json
@@ -81,6 +81,8 @@
   "header-icon-size": "Rozmiar ikony głównej",
   "height": "Wysokość",
   "hide-empty-ws": "Ukryj puste obszary robocze",
+  "hide-show-signal": "Ukryj/pokaż na sygnał",
+  "hide-show-signal-tooltip": "Ukryj/pokaż panel na sygnał RT. Użyj `pkill -f -<signal_number> nwg-panel` w skrócie klawiaturowym.",
   "homogeneous": "Jednorodny",
   "homogeneous-tooltip": "Ustawia domyślnie równą szerokość kolumn jeśli występują moduły środkowe.",
   "horizontal-padding": "Wypełnienie poziome",

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -613,11 +613,15 @@ def main():
             check_key(panel, "css-name", "")
             check_key(panel, "padding-horizontal", 0)
             check_key(panel, "padding-vertical", 0)
-            check_key(panel, "hide_show_sig_num", 0)  # SIGRTMIN > hide_show_sig_num <= SIGRTMAX, (0 = disabled)
+            check_key(panel, "sigrt", 0)  # SIGRTMIN > hide_show_sig_num <= SIGRTMAX, (0 = disabled)
+            check_key(panel, "use-sigrt", False)
 
             window = Gtk.Window()
             global panel_windows_hide_show_sigs
-            panel_windows_hide_show_sigs[window] = panel["hide_show_sig_num"]
+            if panel["use-sigrt"]:
+                panel_windows_hide_show_sigs[window] = panel["hide_show_sig_num"]
+            else:
+                panel_windows_hide_show_sigs[window] = 0
 
             if panel["css-name"]:
                 window.set_property("name", panel["css-name"])

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -93,6 +93,8 @@ restart_cmd = ""
 sig_dwl = 0
 voc = {}
 
+panel_windows_hide_show_sigs = {}
+
 
 def load_vocabulary():
     global voc
@@ -137,6 +139,13 @@ def rt_sig_handler(sig, frame):
         if executor.use_sigrt and executor.sigrt == sig:
             eprint("Refreshing {} on signal {}".format(executor.name, sig))
             executor.refresh()
+
+    for win in panel_windows_hide_show_sigs:
+        if sig == panel_windows_hide_show_sigs[win]:
+            if win.is_visible():
+                win.hide()
+            else:
+                win.show()
 
 
 def restart():
@@ -604,7 +613,12 @@ def main():
             check_key(panel, "css-name", "")
             check_key(panel, "padding-horizontal", 0)
             check_key(panel, "padding-vertical", 0)
+            check_key(panel, "hide_show_sig_num", 0)  # SIGRTMIN > hide_show_sig_num <= SIGRTMAX, (0 = disabled)
+
             window = Gtk.Window()
+            global panel_windows_hide_show_sigs
+            panel_windows_hide_show_sigs[window] = panel["hide_show_sig_num"]
+
             if panel["css-name"]:
                 window.set_property("name", panel["css-name"])
 

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -619,7 +619,7 @@ def main():
             window = Gtk.Window()
             global panel_windows_hide_show_sigs
             if panel["use-sigrt"]:
-                panel_windows_hide_show_sigs[window] = panel["hide_show_sig_num"]
+                panel_windows_hide_show_sigs[window] = panel["sigrt"]
             else:
                 panel_windows_hide_show_sigs[window] = 0
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.9.7',
+    version='0.9.8',
     description='GTK3-based panel for sway and Hyprland Wayland compositors',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Closes  #234

Added support for signals in range `SIRTMIN > signal_number <= SIGRTMAX` to hide/show panels. The signal number (`= SIGRTMAX` by default) must be defined for each panel separately.

![hide-show](https://github.com/nwg-piotr/nwg-panel/assets/20579136/0a82eab0-1713-4f25-a5fd-fa7d5d3e3e97)

You may define a key binding in your `hyprland.conf` file to hide/show certain panels e.g. as below:

```text
bind = $mainMod, F3, exec, pkill -f -64 nwg-panel
```