### PR TITLE
Add start-hidden panel config option

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -868,7 +868,8 @@ class EditorWrapper(object):
             "homogeneous": True,
             "exclusive-zone": True,
             "sigrt": signal.SIGRTMAX,
-            "use-sigrt": False
+            "use-sigrt": False,
+            "start-hidden": False
         }
         for key in defaults:
             check_key(self.panel, key, defaults[key])
@@ -1034,6 +1035,10 @@ class EditorWrapper(object):
         self.panel_use_sigrt.set_label(voc["use-signal"])
         self.panel_use_sigrt.set_active(self.panel["use-sigrt"])
 
+        self.panel_start_hidden = builder.get_object("start-hidden")
+        self.panel_start_hidden.set_label(voc["start-hidden"])
+        self.panel_start_hidden.set_active(self.panel["start-hidden"])
+
         self.cb_homogeneous = builder.get_object("homogeneous")
         self.cb_homogeneous.set_active(self.panel["homogeneous"])
 
@@ -1127,6 +1132,7 @@ class EditorWrapper(object):
 
         self.panel["sigrt"] = int(self.panel_sigrt.get_value())
         self.panel["use-sigrt"] = self.panel_use_sigrt.get_active()
+        self.panel["start-hidden"] = self.panel_start_hidden.get_active()
 
         self.panel["homogeneous"] = self.cb_homogeneous.get_active()
 

--- a/nwg_panel/glade/config_panel.glade
+++ b/nwg_panel/glade/config_panel.glade
@@ -463,6 +463,19 @@
           </packing>
         </child>
         <child>
+          <object class="GtkCheckButton" id="start-hidden">
+            <property name="label" translatable="yes">start hidden</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">3</property>
+            <property name="top-attach">15</property>
+          </packing>
+        </child>
+        <child>
           <placeholder/>
         </child>
         <child>

--- a/nwg_panel/langs/en_US.json
+++ b/nwg_panel/langs/en_US.json
@@ -234,6 +234,7 @@
   "turned-on": "Turned on",
   "units": "Units",
   "use-signal": "Use signal",
+  "start-hidden": "Start hidden",
   "user-menu": "User menu",
   "values-in-widget": "Values in widget",
   "vertical-padding": "Vertical padding",

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -146,7 +146,7 @@ def rt_sig_handler(sig, frame):
             if win.is_visible():
                 win.hide()
             else:
-                win.show()
+                win.show_all()
 
 
 def restart():
@@ -625,6 +625,7 @@ def main():
             check_key(panel, "padding-vertical", 0)
             check_key(panel, "sigrt", 0)  # SIGRTMIN > hide_show_sig_num <= SIGRTMAX, (0 = disabled)
             check_key(panel, "use-sigrt", False)
+            check_key(panel, "start-hidden", False)
 
             window = Gtk.Window()
             global panel_windows_hide_show_sigs
@@ -833,7 +834,10 @@ def main():
             elif panel["position"] == "right":
                 GtkLayerShell.set_anchor(window, GtkLayerShell.Edge.RIGHT, 1)
 
-            window.show_all()
+            if panel["use-sigrt"] and panel["start-hidden"]:
+                window.hide()
+            else:
+                window.show_all()
 
     if sway:
         common.outputs_num = num_active_outputs(common.i3.get_outputs())


### PR DESCRIPTION
This PR adds a "start-hidden" panel config option that results in the panel starting up in the hidden state, as if hidden via the signal specified by "sigrt". The option is ignored if "use-sigrt" is not enabled, since that would hide the window with no way to show it again.