### PR TITLE
Fix syntax error for Python versions earlier than 3.12.

### DIFF
--- a/nwg_panel/processes.py
+++ b/nwg_panel/processes.py
@@ -51,7 +51,7 @@ def hyprctl(cmd):
         f"{xdg_runtime_dir}/hypr") else "/tmp/hypr"
 
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    s.connect(f"{hypr_dir}/{os.getenv("HYPRLAND_INSTANCE_SIGNATURE")}/.socket.sock")
+    s.connect(f"{hypr_dir}/{os.getenv('HYPRLAND_INSTANCE_SIGNATURE')}/.socket.sock")
 
     s.send(cmd.encode("utf-8"))
     output = s.recv(20480).decode('utf-8')

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -827,7 +827,7 @@ def hyprctl(cmd, buf_size=2048):
 
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     try:
-        s.connect(f"{hypr_dir}/{os.getenv("HYPRLAND_INSTANCE_SIGNATURE")}/.socket.sock")
+        s.connect(f"{hypr_dir}/{os.getenv('HYPRLAND_INSTANCE_SIGNATURE')}/.socket.sock")
         s.send(cmd.encode("utf-8"))
 
         output = b""


### PR DESCRIPTION
This commit ensures compatibility with older Python versions by correcting a syntax error in f-strings. The fix involves using single quotes inside the f-string to avoid mismatched parentheses.

Commit 84e01967e2b64f201ecd6eb523c451eb05ed11fb should also include this change.

fix #296