### PR TITLE
fix f-string unmatched quotation mark

### DIFF
--- a/nwg_panel/modules/playerctl.py
+++ b/nwg_panel/modules/playerctl.py
@@ -72,7 +72,7 @@ class Playerctl(Gtk.EventBox):
         if self.num_players > 1:
             self.num_players_lbl.set_text(f" {self.player_idx + 1}/{self.num_players} ")
             self.num_players_lbl.set_tooltip_text(
-                f"Player {self.player_idx + 1}/{self.num_players}, {self.voc["scroll-to-switch"]}")
+                f"Player {self.player_idx + 1}/{self.num_players}, {self.voc['scroll-to-switch']}")
         else:
             self.num_players_lbl.set_text("")
 


### PR DESCRIPTION
This commit will fix 
```console
Traceback (most recent call last):
  File "/nix/store/bdas8vm16h4rdhkhsz53zz8j7p5w6cnz-nwg-panel-0.9.33/bin/.nwg-panel-wrapped", line 6, in <module>
    from nwg_panel.main import main
  File "/nix/store/bdas8vm16h4rdhkhsz53zz8j7p5w6cnz-nwg-panel-0.9.33/lib/python3.11/site-packages/nwg_panel/main.py", line 45, in <module>
    from nwg_panel.modules.playerctl import Playerctl
  File "/nix/store/bdas8vm16h4rdhkhsz53zz8j7p5w6cnz-nwg-panel-0.9.33/lib/python3.11/site-packages/nwg_panel/modules/playerctl.py", line 75
    f"Player {self.player_idx + 1}/{self.num_players}, {self.voc["scroll-to-switch"]}")
                                                                  ^^^^^^
SyntaxError: f-string: unmatched '['
```