### PR TITLE
Activeworkspace

### DIFF
--- a/nwg_panel/glade/config_hyprland_workspaces.glade
+++ b/nwg_panel/glade/config_hyprland_workspaces.glade
@@ -215,7 +215,8 @@
             <property name="halign">start</property>
             <property name="label" translatable="yes">&lt;span size="small"&gt;&lt;b&gt;CSS IDs&lt;/b&gt;: 
 #hyprland-workspaces, #hyprland-workspaces-item, 
-#hyprland-workspaces-icon, #hyprland-workspaces-name&lt;/span&gt;</property>
+#hyprland-workspaces-icon, #hyprland-workspaces-name
+#workspace-occupied&lt;/span&gt;</property>
             <property name="use-markup">True</property>
             <property name="wrap">True</property>
           </object>

--- a/nwg_panel/glade/config_sway_workspaces.glade
+++ b/nwg_panel/glade/config_sway_workspaces.glade
@@ -266,7 +266,8 @@
             <property name="halign">start</property>
             <property name="label" translatable="yes">&lt;span size="small"&gt;&lt;b&gt;CSS IDs&lt;/b&gt;: 
 #sway-workspaces, #sway-workspaces-item,
-#sway-workspaces-icon, #sway-workspaces-name&lt;/span&gt;</property>
+#sway-workspaces-icon, #sway-workspaces-name
+#workspace-occupied&lt;/span&gt;</property>
             <property name="use-markup">True</property>
             <property name="wrap">True</property>
           </object>

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -351,6 +351,7 @@ def instantiate_content(panel, container, content_list, icons_path=""):
                                                     activewindow, activeworkspace, icons_path=icons_path)
                     container.pack_start(workspaces, False, False, panel["items-padding"])
                     common.h_workspaces_list.append(workspaces)
+                    print("Successfully instantiated hyprland-workspaces")
                 else:
                     print("'hyprland-workspaces' not defined in this panel instance")
             else:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -274,9 +274,6 @@ def instantiate_content(panel, container, content_list, icons_path=""):
         else:
             monitors, workspaces, clients, activewindow, activeworkspace = {}, {}, {}, {}, {}
 
-        for item in [monitors, workspaces, clients, activewindow, activeworkspace]:
-            print(">>>", item)
-
     for item in content_list:
         if item == "sway-taskbar":
             if "sway-taskbar" in panel:
@@ -351,7 +348,7 @@ def instantiate_content(panel, container, content_list, icons_path=""):
             if his:
                 if "hyprland-workspaces" in panel:
                     workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
-                                                    activewindow, 2, icons_path=icons_path)
+                                                    activewindow, activeworkspace, icons_path=icons_path)
                     container.pack_start(workspaces, False, False, panel["items-padding"])
                     common.h_workspaces_list.append(workspaces)
                 else:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -264,7 +264,6 @@ def refresh_dwl(*args):
 
 
 def instantiate_content(panel, container, content_list, icons_path=""):
-    print(">>> instantiate_content")
     check_key(panel, "position", "top")
     check_key(panel, "items-padding", 0)
 
@@ -274,6 +273,9 @@ def instantiate_content(panel, container, content_list, icons_path=""):
             monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
         else:
             monitors, workspaces, clients, activewindow, activeworkspace = {}, {}, {}, {}, {}
+
+        for item in [monitors, workspaces, clients, activewindow, activeworkspace]:
+            print(">>>, item")
 
     for item in content_list:
         if item == "sway-taskbar":
@@ -576,7 +578,6 @@ def main():
     common.outputs = list_outputs(sway=sway, tree=tree)
 
     panels = load_json(config_file)
-    print("Panels:", panels)
 
     screen = Gdk.Screen.get_default()
     provider = Gtk.CssProvider()

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -275,7 +275,7 @@ def instantiate_content(panel, container, content_list, icons_path=""):
             monitors, workspaces, clients, activewindow, activeworkspace = {}, {}, {}, {}, {}
 
         for item in [monitors, workspaces, clients, activewindow, activeworkspace]:
-            print(">>>, item")
+            print(">>>", item)
 
     for item in content_list:
         if item == "sway-taskbar":

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -881,6 +881,8 @@ def main():
             thread = threading.Thread(target=hypr_watcher)
             thread.daemon = True
             thread.start()
+    else:
+        print("Hyprland instance signature not found")
 
     if tray_available and len(common.tray_list) > 0:
         sni_system_tray.init_tray(common.tray_list)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -347,10 +347,10 @@ def instantiate_content(panel, container, content_list, icons_path=""):
         if item == "hyprland-workspaces":
             if his:
                 if "hyprland-workspaces" in panel:
-                    workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
-                                                    activewindow, {}, icons_path=icons_path)
-                    container.pack_start(workspaces, False, False, panel["items-padding"])
-                    common.h_workspaces_list.append(workspaces)
+                    # workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
+                    #                                 activewindow, activeworkspaces, icons_path=icons_path)
+                    # container.pack_start(workspaces, False, False, panel["items-padding"])
+                    # common.h_workspaces_list.append(workspaces)
                     print("Successfully instantiated hyprland-workspaces")
                 else:
                     print("'hyprland-workspaces' not defined in this panel instance")

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -347,10 +347,11 @@ def instantiate_content(panel, container, content_list, icons_path=""):
         if item == "hyprland-workspaces":
             if his:
                 if "hyprland-workspaces" in panel:
-                    # workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
-                    #                                 activewindow, activeworkspaces, icons_path=icons_path)
-                    # container.pack_start(workspaces, False, False, panel["items-padding"])
-                    # common.h_workspaces_list.append(workspaces)
+                    print("activeworkspace:", activeworkspace)
+                    workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
+                                                    activewindow, activeworkspace, icons_path=icons_path)
+                    container.pack_start(workspaces, False, False, panel["items-padding"])
+                    common.h_workspaces_list.append(workspaces)
                     print("Successfully instantiated hyprland-workspaces")
                 else:
                     print("'hyprland-workspaces' not defined in this panel instance")

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -347,7 +347,6 @@ def instantiate_content(panel, container, content_list, icons_path=""):
         if item == "hyprland-workspaces":
             if his:
                 if "hyprland-workspaces" in panel:
-                    print("activeworkspace:", activeworkspace)
                     workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
                                                     activewindow, activeworkspace, icons_path=icons_path)
                     container.pack_start(workspaces, False, False, panel["items-padding"])

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -264,6 +264,7 @@ def refresh_dwl(*args):
 
 
 def instantiate_content(panel, container, content_list, icons_path=""):
+    print(">>> instantiate_content")
     check_key(panel, "position", "top")
     check_key(panel, "items-padding", 0)
 
@@ -575,6 +576,7 @@ def main():
     common.outputs = list_outputs(sway=sway, tree=tree)
 
     panels = load_json(config_file)
+    print("Panels:", panels)
 
     screen = Gdk.Screen.get_default()
     provider = Gtk.CssProvider()
@@ -881,8 +883,6 @@ def main():
             thread = threading.Thread(target=hypr_watcher)
             thread.daemon = True
             thread.start()
-    else:
-        print("Hyprland instance signature not found")
 
     if tray_available and len(common.tray_list) > 0:
         sni_system_tray.init_tray(common.tray_list)

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -351,7 +351,6 @@ def instantiate_content(panel, container, content_list, icons_path=""):
                                                     activewindow, activeworkspace, icons_path=icons_path)
                     container.pack_start(workspaces, False, False, panel["items-padding"])
                     common.h_workspaces_list.append(workspaces)
-                    print("Successfully instantiated hyprland-workspaces")
                 else:
                     print("'hyprland-workspaces' not defined in this panel instance")
             else:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -347,9 +347,9 @@ def instantiate_content(panel, container, content_list, icons_path=""):
         if item == "hyprland-workspaces":
             if his:
                 if "hyprland-workspaces" in panel:
-                    print("activeworkspace:", activeworkspace)
                     workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
                                                     activewindow, activeworkspace, icons_path=icons_path)
+                    print("workspaces", workspaces)
                     container.pack_start(workspaces, False, False, panel["items-padding"])
                     common.h_workspaces_list.append(workspaces)
                     print("Successfully instantiated hyprland-workspaces")

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -185,54 +185,54 @@ def hypr_watcher():
 
         event_name = e_full_string.split(">>")[0]
 
-        if event_name in ["monitoradded", "openwindow", "movewindow"]:
-            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-            for item in common.h_taskbars_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-            last_client_title = client_title
-            last_client_addr = client_addr
-            continue
-
-        if event_name == "focusedmon":
-            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-            for item in common.h_workspaces_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-            last_client_title = client_title
-            last_client_addr = client_addr
-            continue
-
-        if event_name == "activewindow" and client_title != last_client_title:
-            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-            for item in common.h_taskbars_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-
-            for item in common.h_workspaces_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-
-            last_client_title = client_title
-            continue
-
-        if event_name == "activewindowv2" and client_addr != last_client_addr:
-            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-            for item in common.h_taskbars_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-
-            for item in common.h_workspaces_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-
-            last_client_addr = client_addr
-            continue
-
-        if event_name in ["changefloatingmode", "closewindow"]:
-            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-            for item in common.h_taskbars_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-
-            for item in common.h_workspaces_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-
-            last_client_addr = ""
-            last_client_title = ""
+        # if event_name in ["monitoradded", "openwindow", "movewindow"]:
+        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+        #     for item in common.h_taskbars_list:
+        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+        #     last_client_title = client_title
+        #     last_client_addr = client_addr
+        #     continue
+        #
+        # if event_name == "focusedmon":
+        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+        #     for item in common.h_workspaces_list:
+        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+        #     last_client_title = client_title
+        #     last_client_addr = client_addr
+        #     continue
+        #
+        # if event_name == "activewindow" and client_title != last_client_title:
+        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+        #     for item in common.h_taskbars_list:
+        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+        #
+        #     for item in common.h_workspaces_list:
+        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+        #
+        #     last_client_title = client_title
+        #     continue
+        #
+        # if event_name == "activewindowv2" and client_addr != last_client_addr:
+        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+        #     for item in common.h_taskbars_list:
+        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+        #
+        #     for item in common.h_workspaces_list:
+        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+        #
+        #     last_client_addr = client_addr
+        #     continue
+        #
+        # if event_name in ["changefloatingmode", "closewindow"]:
+        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+        #     for item in common.h_taskbars_list:
+        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+        #
+        #     for item in common.h_workspaces_list:
+        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+        #
+        #     last_client_addr = ""
+        #     last_client_title = ""
 
 
 def on_i3ipc_event(i3conn, event):

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -347,6 +347,7 @@ def instantiate_content(panel, container, content_list, icons_path=""):
         if item == "hyprland-workspaces":
             if his:
                 if "hyprland-workspaces" in panel:
+                    print("activeworkspace:", activeworkspace)
                     workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
                                                     activewindow, activeworkspace, icons_path=icons_path)
                     container.pack_start(workspaces, False, False, panel["items-padding"])

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -351,7 +351,7 @@ def instantiate_content(panel, container, content_list, icons_path=""):
             if his:
                 if "hyprland-workspaces" in panel:
                     workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
-                                                    activewindow, activeworkspace, icons_path=icons_path)
+                                                    activewindow, 2, icons_path=icons_path)
                     container.pack_start(workspaces, False, False, panel["items-padding"])
                     common.h_workspaces_list.append(workspaces)
                 else:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -185,54 +185,54 @@ def hypr_watcher():
 
         event_name = e_full_string.split(">>")[0]
 
-        # if event_name in ["monitoradded", "openwindow", "movewindow"]:
-        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-        #     for item in common.h_taskbars_list:
-        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-        #     last_client_title = client_title
-        #     last_client_addr = client_addr
-        #     continue
-        #
-        # if event_name == "focusedmon":
-        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-        #     for item in common.h_workspaces_list:
-        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-        #     last_client_title = client_title
-        #     last_client_addr = client_addr
-        #     continue
-        #
-        # if event_name == "activewindow" and client_title != last_client_title:
-        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-        #     for item in common.h_taskbars_list:
-        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-        #
-        #     for item in common.h_workspaces_list:
-        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-        #
-        #     last_client_title = client_title
-        #     continue
-        #
-        # if event_name == "activewindowv2" and client_addr != last_client_addr:
-        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-        #     for item in common.h_taskbars_list:
-        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-        #
-        #     for item in common.h_workspaces_list:
-        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-        #
-        #     last_client_addr = client_addr
-        #     continue
-        #
-        # if event_name in ["changefloatingmode", "closewindow"]:
-        #     monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
-        #     for item in common.h_taskbars_list:
-        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-        #
-        #     for item in common.h_workspaces_list:
-        #         GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
-        #
-        #     last_client_addr = ""
-        #     last_client_title = ""
+        if event_name in ["monitoradded", "openwindow", "movewindow"]:
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+            for item in common.h_taskbars_list:
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+            last_client_title = client_title
+            last_client_addr = client_addr
+            continue
+
+        if event_name == "focusedmon":
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+            for item in common.h_workspaces_list:
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+            last_client_title = client_title
+            last_client_addr = client_addr
+            continue
+
+        if event_name == "activewindow" and client_title != last_client_title:
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+            for item in common.h_taskbars_list:
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+
+            for item in common.h_workspaces_list:
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+
+            last_client_title = client_title
+            continue
+
+        if event_name == "activewindowv2" and client_addr != last_client_addr:
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+            for item in common.h_taskbars_list:
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+
+            for item in common.h_workspaces_list:
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+
+            last_client_addr = client_addr
+            continue
+
+        if event_name in ["changefloatingmode", "closewindow"]:
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
+            for item in common.h_taskbars_list:
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+
+            for item in common.h_workspaces_list:
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
+
+            last_client_addr = ""
+            last_client_title = ""
 
 
 def on_i3ipc_event(i3conn, event):

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -186,50 +186,50 @@ def hypr_watcher():
         event_name = e_full_string.split(">>")[0]
 
         if event_name in ["monitoradded", "openwindow", "movewindow"]:
-            monitors, workspaces, clients, activewindow = h_modules_get_all()
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
             for item in common.h_taskbars_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow)
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
             last_client_title = client_title
             last_client_addr = client_addr
             continue
 
         if event_name == "focusedmon":
-            monitors, workspaces, clients, activewindow = h_modules_get_all()
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
             for item in common.h_workspaces_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow)
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
             last_client_title = client_title
             last_client_addr = client_addr
             continue
 
         if event_name == "activewindow" and client_title != last_client_title:
-            monitors, workspaces, clients, activewindow = h_modules_get_all()
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
             for item in common.h_taskbars_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow)
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
 
             for item in common.h_workspaces_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow)
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
 
             last_client_title = client_title
             continue
 
         if event_name == "activewindowv2" and client_addr != last_client_addr:
-            monitors, workspaces, clients, activewindow = h_modules_get_all()
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
             for item in common.h_taskbars_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow)
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
 
             for item in common.h_workspaces_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow)
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
 
             last_client_addr = client_addr
             continue
 
         if event_name in ["changefloatingmode", "closewindow"]:
-            monitors, workspaces, clients, activewindow = h_modules_get_all()
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
             for item in common.h_taskbars_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow)
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
 
             for item in common.h_workspaces_list:
-                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow)
+                GLib.timeout_add(0, item.refresh, monitors, workspaces, clients, activewindow, activeworkspace)
 
             last_client_addr = ""
             last_client_title = ""
@@ -270,9 +270,9 @@ def instantiate_content(panel, container, content_list, icons_path=""):
     # list initial data for Hyprland modules
     if his:
         if "hyprland-workspaces" in content_list or "hyprland-taskbar" in content_list:
-            monitors, workspaces, clients, activewindow = h_modules_get_all()
+            monitors, workspaces, clients, activewindow, activeworkspace = h_modules_get_all()
         else:
-            monitors, workspaces, clients, activewindow = {}, {}, {}, {}
+            monitors, workspaces, clients, activewindow, activeworkspace = {}, {}, {}, {}, {}
 
     for item in content_list:
         if item == "sway-taskbar":
@@ -348,7 +348,7 @@ def instantiate_content(panel, container, content_list, icons_path=""):
             if his:
                 if "hyprland-workspaces" in panel:
                     workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
-                                                    activewindow, icons_path=icons_path)
+                                                    activewindow, activeworkspace, icons_path=icons_path)
                     container.pack_start(workspaces, False, False, panel["items-padding"])
                     common.h_workspaces_list.append(workspaces)
                 else:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -348,8 +348,7 @@ def instantiate_content(panel, container, content_list, icons_path=""):
             if his:
                 if "hyprland-workspaces" in panel:
                     workspaces = HyprlandWorkspaces(panel["hyprland-workspaces"], monitors, workspaces, clients,
-                                                    activewindow, activeworkspace, icons_path=icons_path)
-                    print("workspaces", workspaces)
+                                                    activewindow, {}, icons_path=icons_path)
                     container.pack_start(workspaces, False, False, panel["items-padding"])
                     common.h_workspaces_list.append(workspaces)
                     print("Successfully instantiated hyprland-workspaces")

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -79,8 +79,8 @@ class HyprlandWorkspaces(Gtk.Box):
             name = "{} {}".format(num, self.ws_id2name[num])
 
         lbl = Gtk.Label.new("{}".format(name)) if not add_dot else Gtk.Label.new("{}.".format(name))
-        if add_dot:
-            lbl.set_property("name", "workspace-occupied")
+        # if add_dot:
+        #     lbl.set_property("name", "workspace-occupied")
         lbl.set_use_markup(True)
         if self.settings["angle"] != 0.0:
             lbl.set_angle(self.settings["angle"])
@@ -124,8 +124,11 @@ class HyprlandWorkspaces(Gtk.Box):
 
         for num in self.ws_nums:
             if num in occupied_workspaces or self.settings["show-empty"]:
+                occ = num in occupied_workspaces
                 dot = num in occupied_workspaces and self.settings["show-empty"] and self.settings["mark-content"]
                 eb, lbl = self.build_number(num, add_dot=dot, active_win_ws=active_ws)
+                if occ:
+                    lbl.set_property("name", "workspace-occupied")
                 self.num_box.pack_start(eb, False, False, 0)
                 self.num_box.show_all()
 

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -27,7 +27,7 @@ class HyprlandWorkspaces(Gtk.Box):
         print("clients", clients)
         print("activewindow", activewindow)
         print("activeworkspace", activeworkspace)
-        self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
+        # self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
 
     def build_box(self):
         check_key(self.settings, "num-ws", 10)

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -22,7 +22,7 @@ class HyprlandWorkspaces(Gtk.Box):
         self.ws_nums = []
 
         self.build_box()
-        if activeworkspace:
+        if "id" in activeworkspace:
             self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
 
     def build_box(self):

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -7,6 +7,7 @@ from nwg_panel.tools import check_key, update_image_fallback_desktop, hyprctl
 
 class HyprlandWorkspaces(Gtk.Box):
     def __init__(self, settings, monitors, workspaces, clients, activewindow, activeworkspace, icons_path):
+        print("HyprlandWorkspaces activeworkspace:", activeworkspace)
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         self.settings = settings
         self.num_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -7,7 +7,6 @@ from nwg_panel.tools import check_key, update_image_fallback_desktop, hyprctl
 
 class HyprlandWorkspaces(Gtk.Box):
     def __init__(self, settings, monitors, workspaces, clients, activewindow, activeworkspace, icons_path):
-        print("HyprlandWorkspaces activeworkspace:", activeworkspace)
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         self.settings = settings
         self.num_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
@@ -23,7 +22,7 @@ class HyprlandWorkspaces(Gtk.Box):
         self.ws_nums = []
 
         self.build_box()
-        self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
+        # self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
 
     def build_box(self):
         check_key(self.settings, "num-ws", 10)

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -116,7 +116,6 @@ class HyprlandWorkspaces(Gtk.Box):
 
         # fix #310
         active_ws = activeworkspace["id"]
-        print(">>> active_ws", active_ws)
 
         for num in self.ws_nums:
             if num in occupied_workspaces or self.settings["show-empty"]:

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -115,10 +115,7 @@ class HyprlandWorkspaces(Gtk.Box):
             pinned = activewindow["pinned"]
 
         # fix #310
-        if activeworkspace and "id" in activeworkspace:
-            active_ws = activeworkspace["id"]
-        else:
-            active_ws = 0
+        active_ws = activeworkspace["id"]
 
         for num in self.ws_nums:
             if num in occupied_workspaces or self.settings["show-empty"]:

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -22,7 +22,7 @@ class HyprlandWorkspaces(Gtk.Box):
         self.ws_nums = []
 
         self.build_box()
-        # self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
+        self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
 
     def build_box(self):
         check_key(self.settings, "num-ws", 10)
@@ -115,7 +115,8 @@ class HyprlandWorkspaces(Gtk.Box):
             pinned = activewindow["pinned"]
 
         # fix #310
-        active_ws = activeworkspace["id"]
+        # active_ws = activeworkspace["id"]
+        active_ws = 0
 
         for num in self.ws_nums:
             if num in occupied_workspaces or self.settings["show-empty"]:

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -22,8 +22,12 @@ class HyprlandWorkspaces(Gtk.Box):
         self.ws_nums = []
 
         self.build_box()
-        if "id" in activeworkspace:
-            self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
+        print("monitors", monitors)
+        print("workspaces", workspaces)
+        print("clients", clients)
+        print("activewindow", activewindow)
+        print("activeworkspace", activeworkspace)
+        self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
 
     def build_box(self):
         check_key(self.settings, "num-ws", 10)

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -7,6 +7,7 @@ from nwg_panel.tools import check_key, update_image_fallback_desktop, hyprctl
 
 class HyprlandWorkspaces(Gtk.Box):
     def __init__(self, settings, monitors, workspaces, clients, activewindow, activeworkspace, icons_path):
+        print(">>> activeworkspace:", activeworkspace)
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         self.settings = settings
         self.num_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -22,7 +22,8 @@ class HyprlandWorkspaces(Gtk.Box):
         self.ws_nums = []
 
         self.build_box()
-        self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
+        if activeworkspace:
+            self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
 
     def build_box(self):
         check_key(self.settings, "num-ws", 10)
@@ -115,8 +116,7 @@ class HyprlandWorkspaces(Gtk.Box):
             pinned = activewindow["pinned"]
 
         # fix #310
-        # active_ws = activeworkspace["id"]
-        active_ws = 0
+        active_ws = activeworkspace["id"]
 
         for num in self.ws_nums:
             if num in occupied_workspaces or self.settings["show-empty"]:

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -7,7 +7,6 @@ from nwg_panel.tools import check_key, update_image_fallback_desktop, hyprctl
 
 class HyprlandWorkspaces(Gtk.Box):
     def __init__(self, settings, monitors, workspaces, clients, activewindow, activeworkspace, icons_path):
-        print(">>> activeworkspace:", activeworkspace)
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         self.settings = settings
         self.num_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
@@ -117,6 +116,7 @@ class HyprlandWorkspaces(Gtk.Box):
 
         # fix #310
         active_ws = activeworkspace["id"]
+        print(">>> active_ws", active_ws)
 
         for num in self.ws_nums:
             if num in occupied_workspaces or self.settings["show-empty"]:

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -6,7 +6,7 @@ from nwg_panel.tools import check_key, update_image_fallback_desktop, hyprctl
 
 
 class HyprlandWorkspaces(Gtk.Box):
-    def __init__(self, settings, monitors, workspaces, clients, activewindow, icons_path):
+    def __init__(self, settings, monitors, workspaces, clients, activewindow, activeworkspace, icons_path):
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         self.settings = settings
         self.num_box = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, 0)
@@ -22,7 +22,7 @@ class HyprlandWorkspaces(Gtk.Box):
         self.ws_nums = []
 
         self.build_box()
-        self.refresh(monitors, workspaces, clients, activewindow)
+        self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
 
     def build_box(self):
         check_key(self.settings, "num-ws", 10)
@@ -90,7 +90,7 @@ class HyprlandWorkspaces(Gtk.Box):
 
         return eb, lbl
 
-    def refresh(self, monitors, workspaces, clients, activewindow):
+    def refresh(self, monitors, workspaces, clients, activewindow, activeworkspace):
         occupied_workspaces = []
         self.ws_id2name = {}
 
@@ -113,16 +113,9 @@ class HyprlandWorkspaces(Gtk.Box):
                 client_title = "X|{}".format(client_title)
             floating = activewindow["floating"]
             pinned = activewindow["pinned"]
-            active_ws = activewindow["workspace"]["id"]
-        else:
-            client_class = ""
-            client_title = ""
-            floating = False
-            pinned = False
-            for m in monitors:
-                if m["focused"]:
-                    active_ws = m["activeWorkspace"]["id"]
-                    break
+
+        # fix #310
+        active_ws = activeworkspace["id"]
 
         for num in self.ws_nums:
             if num in occupied_workspaces or self.settings["show-empty"]:

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -22,12 +22,7 @@ class HyprlandWorkspaces(Gtk.Box):
         self.ws_nums = []
 
         self.build_box()
-        print("monitors", monitors)
-        print("workspaces", workspaces)
-        print("clients", clients)
-        print("activewindow", activewindow)
-        print("activeworkspace", activeworkspace)
-        # self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
+        self.refresh(monitors, workspaces, clients, activewindow, activeworkspace)
 
     def build_box(self):
         check_key(self.settings, "num-ws", 10)
@@ -118,6 +113,11 @@ class HyprlandWorkspaces(Gtk.Box):
                 client_title = "X|{}".format(client_title)
             floating = activewindow["floating"]
             pinned = activewindow["pinned"]
+        else:
+            client_class = ""
+            client_title = ""
+            floating = False
+            pinned = False
 
         # fix #310
         active_ws = activeworkspace["id"]

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -115,7 +115,10 @@ class HyprlandWorkspaces(Gtk.Box):
             pinned = activewindow["pinned"]
 
         # fix #310
-        active_ws = activeworkspace["id"]
+        if activeworkspace and "id" in activeworkspace:
+            active_ws = activeworkspace["id"]
+        else:
+            active_ws = 0
 
         for num in self.ws_nums:
             if num in occupied_workspaces or self.settings["show-empty"]:

--- a/nwg_panel/modules/sway_workspaces.py
+++ b/nwg_panel/modules/sway_workspaces.py
@@ -171,10 +171,13 @@ class SwayWorkspaces(Gtk.Box):
                     else:
                         lbl.hide()
 
+                    # mark non-empty WS with CSS ID
+                    if int_num in non_empty:
+                        lbl.set_property("name", "workspace-occupied")
+
                     # mark non-empty WS with a dot
                     if self.settings["mark-content"]:
                         if int_num in non_empty:
-                            lbl.set_property("name", "workspace-occupied")
                             if not text.endswith("."):
                                 text += "."
                         else:
@@ -263,13 +266,13 @@ class SwayWorkspaces(Gtk.Box):
             for item in tree.descendants():
                 if item.type == "workspace":
                     # find non-empty workspaces
-                    if self.settings["mark-content"] or self.settings["hide-empty"]:
-                        tasks_num = 0
-                        for d in item.descendants():
-                            if d.type == "con" and d.name:
-                                tasks_num += 1
-                        if tasks_num > 0:
-                            non_empty.append(item.num)
+                    # if self.settings["mark-content"] or self.settings["hide-empty"]:
+                    tasks_num = 0
+                    for d in item.descendants():
+                        if d.type == "con" and d.name:
+                            tasks_num += 1
+                    if tasks_num > 0:
+                        non_empty.append(item.num)
 
                     for node in item.floating_nodes:
                         if str(node.workspace().num) in self.settings["numbers"]:

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -887,6 +887,7 @@ def h_get_activewindow():
 
 def h_get_active_workspace():
     reply = hyprctl("j/activeworkspace")
+    print(">>> reply:", reply)
     try:
         return json.loads(reply)
     except Exception as e:

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -887,7 +887,6 @@ def h_get_activewindow():
 
 def h_get_active_workspace():
     reply = hyprctl("j/activeworkspace")
-    print(">>> reply:", reply)
     try:
         return json.loads(reply)
     except Exception as e:

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -885,8 +885,17 @@ def h_get_activewindow():
         return {}
 
 
+def h_get_active_workspace():
+    reply = hyprctl("j/activeworkspace")
+    try:
+        return json.loads(reply)
+    except Exception as e:
+        eprint(e)
+        return {}
+
+
 def h_modules_get_all():
-    return h_list_monitors(), h_list_workspaces(), h_list_clients(), h_get_activewindow()
+    return h_list_monitors(), h_list_workspaces(), h_list_clients(), h_get_activewindow(), h_get_active_workspace()
 
 
 def cmd_through_compositor(cmd):


### PR DESCRIPTION
- Added `hyprctl activeworkspace` check, for the workspaces module to work w/ empty workspaces; closes #310 
- `workspace-occupied` name property (CSS ID) from now on added for empty workspaces regardless of the "Mark empty workspaces" (w/ a dot) setting.