### PR TITLE
Fix crashes on wsl-randr if a monitor is disabled

### DIFF
--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -358,6 +358,10 @@ def list_outputs(sway=False, tree=None, silent=False):
                                                   'transform': transform,
                                                   'scale': scale,
                                                   'monitor': None}
+                        #Each monitor only have a single transform this avoid parsing multiple times the same monitor
+                        #Disabled monitors don't have transforms.
+                        # Gdk doesn't report disabled monitor, not filtering them would cause crashes
+                        transform = None
         else:
             print("'wlr-randr' command not found, terminating")
             sys.exit(1)

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -375,10 +375,8 @@ def list_outputs(sway=False, tree=None, silent=False):
         monitor = display.get_monitor(i)
         monitors.append(monitor)
 
-    idx = 0
-    for key in outputs_dict:
-        outputs_dict[key]["monitor"] = monitors[idx]
-        idx += 1
+    for key, monitor in zip(outputs_dict.keys(), monitors):
+        outputs_dict[key]["monitor"] = monitor
 
     return outputs_dict
 


### PR DESCRIPTION
Hi this is a small patch to fix crashes while using wsl-randr.

I joined the output of wlr-randr on my system. As you can see, I disabled one of my monitors. This lead to crashes. 

```py
    monitors = []
    display = Gdk.Display.get_default()
    for i in range(display.get_n_monitors()):
        monitor = display.get_monitor(i)
        monitors.append(monitor)

    idx = 0
    for key in outputs_dict:
        outputs_dict[key]["monitor"] = monitors[idx]
        idx += 1
```
The first loop ask GDK what are the displays available on my system. Which as far as Gdk is concerned there is only one "DP-1". 

But since wlr-randr listed 2 displays output_dict contains my 2 display. this means that during the second iteration of the second loop we try to access monitors[1] which is out of bound. and crash python.

```python
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.12/nwg-panel", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.12/site-packages/nwg_panel/main.py", line 575, in main
    common.outputs = list_outputs(sway=sway, tree=tree)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/nwg_panel/tools.py", line 377, in list_outputs
    outputs_dict[key]["monitor"] = monitors[idx]
                                   ~~~~~~~~^^^^^
```


```bash
$ wlr-randr
DP-1 "Acer Technologies VG240Y V 0x03421FD4 (DP-1)"
  Make: Acer Technologies
  Model: VG240Y V
  Serial: 0x03421FD4
  Physical size: 530x300 mm
  Enabled: yes
  Modes:
    1920x1080 px, 143.854996 Hz (preferred, current)
    1920x1080 px, 165.003006 Hz
    1920x1080 px, 119.878998 Hz
    1920x1080 px, 119.877998 Hz
    1920x1080 px, 60.000000 Hz
    1920x1080 px, 59.938999 Hz
    1920x1080 px, 50.000000 Hz
    1680x1050 px, 59.953999 Hz
    1280x1024 px, 75.025002 Hz
    1280x1024 px, 60.020000 Hz
    1440x900 px, 59.887001 Hz
    1280x960 px, 60.000000 Hz
    1280x800 px, 59.810001 Hz
    1152x864 px, 75.000000 Hz
    1280x720 px, 60.000000 Hz
    1280x720 px, 59.943001 Hz
    1280x720 px, 50.000000 Hz
    1024x768 px, 75.028999 Hz
    1024x768 px, 70.069000 Hz
    1024x768 px, 60.004002 Hz
    800x600 px, 75.000000 Hz
    800x600 px, 72.188004 Hz
    800x600 px, 60.317001 Hz
    800x600 px, 56.250000 Hz
    720x576 px, 50.000000 Hz
    720x480 px, 59.939999 Hz
    640x480 px, 75.000000 Hz
    640x480 px, 72.808998 Hz
    640x480 px, 59.939999 Hz
    640x480 px, 59.929001 Hz
  Position: 1920,0
  Transform: normal
  Scale: 1.000000
  Adaptive Sync: disabled
eDP-1 "BOE 0x0995 (eDP-1)"
  Make: BOE
  Model: 0x0995
  Serial: (null)
  Physical size: 380x220 mm
  Enabled: no
  Modes:
    1920x1080 px, 144.003006 Hz (preferred)
    1920x1080 px, 60.000999 Hz
    1680x1050 px, 144.003006 Hz
    1280x1024 px, 144.003006 Hz
    1440x900 px, 144.003006 Hz
    1280x800 px, 144.003006 Hz
    1280x720 px, 144.003006 Hz
    1024x768 px, 144.003006 Hz
    800x600 px, 144.003006 Hz
    640x480 px, 144.003006 Hz
```