### PR TITLE
Workaround for hyprctl empty devices lists

### DIFF
--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -761,12 +761,14 @@ def main():
                 left_box.pack_start(ms, False, False, 0)
 
             instantiate_content(panel, left_box, panel["modules-left"], icons_path=icons_path)
+            print("left box created")
 
             center_box = Gtk.Box(orientation=o, spacing=panel["spacing"])
             center_box.set_property("name", "center-box")
             inner_box.pack_start(center_box, True, False, 0)
             check_key(panel, "modules-center", [])
             instantiate_content(panel, center_box, panel["modules-center"], icons_path=icons_path)
+            print("center box created")
 
             right_box = Gtk.Box(orientation=o, spacing=panel["spacing"])
             right_box.set_property("name", "right-box")
@@ -776,6 +778,7 @@ def main():
             inner_box.pack_start(helper_box, False, True, 0)
             check_key(panel, "modules-right", [])
             instantiate_content(panel, right_box, panel["modules-right"], icons_path=icons_path)
+            print("right box created")
 
             if panel["menu-start"] == "right":
                 ms = MenuStart(panel["menu-start-settings"], icons_path=icons_path)

--- a/nwg_panel/modules/keyboard_layout.py
+++ b/nwg_panel/modules/keyboard_layout.py
@@ -95,7 +95,7 @@ class KeyboardLayout(Gtk.EventBox):
                     self.label.set_text(label)
                 self.show_all()
             else:
-                eprint("KeyboardLayout module: failed listing devices, won't create UI, sorry.")
+                print("KeyboardLayout module: failed listing devices, won't create UI, sorry.")
 
 
     def list_keyboards(self):

--- a/nwg_panel/modules/keyboard_layout.py
+++ b/nwg_panel/modules/keyboard_layout.py
@@ -97,7 +97,6 @@ class KeyboardLayout(Gtk.EventBox):
             else:
                 print("KeyboardLayout module: failed listing devices, won't create UI, sorry.")
 
-
     def list_keyboards(self):
         if self.compositor == "Hyprland":
             o = hyprctl("j/devices")

--- a/nwg_panel/modules/keyboard_layout.py
+++ b/nwg_panel/modules/keyboard_layout.py
@@ -94,6 +94,9 @@ class KeyboardLayout(Gtk.EventBox):
                 if label:
                     self.label.set_text(label)
                 self.show_all()
+            else:
+                eprint("KeyboardLayout module: failed listing devices, won't create UI, sorry.")
+
 
     def list_keyboards(self):
         if self.compositor == "Hyprland":

--- a/nwg_panel/modules/keyboard_layout.py
+++ b/nwg_panel/modules/keyboard_layout.py
@@ -45,54 +45,55 @@ class KeyboardLayout(Gtk.EventBox):
 
         if self.compositor:
             self.keyboards = self.list_keyboards()
-            self.keyboard_names = []
-            for k in self.keyboards:
-                if self.compositor == "Hyprland":
-                    self.keyboard_names.append(k["name"])
-                # On sway some devices may be listed twice, let's add them just once
-                elif k.identifier not in self.keyboard_names:
-                    self.keyboard_names.append(k.identifier)
-            # print(f"keyboard_names = {self.keyboard_names}")
+            if self.keyboards:
+                self.keyboard_names = []
+                for k in self.keyboards:
+                    if self.compositor == "Hyprland":
+                        self.keyboard_names.append(k["name"])
+                    # On sway some devices may be listed twice, let's add them just once
+                    elif k.identifier not in self.keyboard_names:
+                        self.keyboard_names.append(k.identifier)
 
-            self.kb_layouts = self.get_kb_layouts()
-            # print(f"kb_layouts = {self.kb_layouts}")
+                self.kb_layouts = self.get_kb_layouts()
 
-            check_key(settings, "keyboard-device-sway", "")
-            check_key(settings, "keyboard-device-hyprland", "")
-            self.device_name = settings["keyboard-device-sway"] if self.compositor == "sway" else settings[
-                "keyboard-device-hyprland"]
+                check_key(settings, "keyboard-device-sway", "")
+                check_key(settings, "keyboard-device-hyprland", "")
+                self.device_name = settings["keyboard-device-sway"] if self.compositor == "sway" else settings[
+                    "keyboard-device-hyprland"]
 
-            check_key(settings, "root-css-name", "root-executor")
-            check_key(settings, "css-name", "")
-            check_key(settings, "icon-placement", "left")
-            check_key(settings, "icon-size", 16)
-            check_key(settings, "show-icon", True)
-            check_key(settings, "tooltip-text", "LMB: Next layout, RMB: Menu")
-            check_key(settings, "angle", 0.0)
+                check_key(settings, "root-css-name", "root-executor")
+                check_key(settings, "css-name", "")
+                check_key(settings, "icon-placement", "left")
+                check_key(settings, "icon-size", 16)
+                check_key(settings, "show-icon", True)
+                check_key(settings, "tooltip-text", "LMB: Next layout, RMB: Menu")
+                check_key(settings, "angle", 0.0)
 
-            self.label.set_angle(settings["angle"])
+                self.label.set_angle(settings["angle"])
 
-            if settings["angle"] != 0.0:
-                self.box.set_orientation(Gtk.Orientation.VERTICAL)
+                if settings["angle"] != 0.0:
+                    self.box.set_orientation(Gtk.Orientation.VERTICAL)
 
-            update_image(self.image, "input-keyboard", self.settings["icon-size"], self.icons_path)
+                update_image(self.image, "input-keyboard", self.settings["icon-size"], self.icons_path)
 
-            self.set_property("name", settings["root-css-name"])
-            if settings["css-name"]:
-                self.label.set_property("name", settings["css-name"])
-            else:
-                self.label.set_property("name", "executor-label")
+                self.set_property("name", settings["root-css-name"])
+                if settings["css-name"]:
+                    self.label.set_property("name", settings["css-name"])
+                else:
+                    self.label.set_property("name", "executor-label")
 
-            if settings["tooltip-text"]:
-                self.set_tooltip_text(settings["tooltip-text"])
+                if settings["tooltip-text"]:
+                    self.set_tooltip_text(settings["tooltip-text"])
 
-            self.connect('button-release-event', self.on_button_release)
-            self.connect('enter-notify-event', on_enter_notify_event)
-            self.connect('leave-notify-event', on_leave_notify_event)
+                self.connect('button-release-event', self.on_button_release)
+                self.connect('enter-notify-event', on_enter_notify_event)
+                self.connect('leave-notify-event', on_leave_notify_event)
 
-            self.build_box()
-            self.refresh()
-            self.show_all()
+                self.build_box()
+                label = self.get_current_layout()
+                if label:
+                    self.label.set_text(label)
+                self.show_all()
 
     def list_keyboards(self):
         if self.compositor == "Hyprland":

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.9.38',
+    version='0.9.39',
     description='GTK3-based panel for sway and Hyprland Wayland compositors',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
On just started Hyprland 0.43.0 `hyprctl devices` happens (in most cases) to return empty devices lists: `{'mice': [], 'keyboards': [], 'tablets': [], 'touch': [], 'switches': []}`. When it happens, this fix skips the KeyboardLayout module UI creation, in order to prevent the entire panel from hanging. BTW: if you restart the panel after awhile, the module should start properly. Related Hyprland issue: https://github.com/hyprwm/Hyprland/issues/7843.