### PR TITLE
controls/PopupWindow: refresh parent outputs as part of our refresh

### DIFF
--- a/nwg_panel/modules/controls.py
+++ b/nwg_panel/modules/controls.py
@@ -619,7 +619,6 @@ class PopupWindow(Gtk.Window):
 
     def toggle_mute(self, e, slider):
         toggle_mute()
-        self.parent.refresh()
         self.refresh()
 
     def custom_item(self, name, icon, cmd):
@@ -651,6 +650,7 @@ class PopupWindow(Gtk.Window):
     def refresh(self, schedule=False):
         if self.get_visible():
             self.refresh_sinks()
+            self.parent.refresh_output()
 
             if "battery" in self.settings["components"]:
                 if self.parent.bat_icon_name != self.bat_icon_name:


### PR DESCRIPTION
1. this fixes a BUG where toggling the mute schedules not a one-time refresh of that data, but rather schedules a _recurring_ refresh, effectively doubling the parent's refresh rate (or tripling, if toggled twice, quadrupling if toggled three times, ...). it was calling the wrong `parent.refresh` method.

2. if the user has `show-{battery,brightness,volume}` set false, then they can now safely set a very infrequent refresh interval on the main panel, and rely on the PopupWindow refreshing that at its own interval, when actually needed.