### PR TITLE
Assign panels to monitor descriptions

### DIFF
--- a/nwg_panel/common.py
+++ b/nwg_panel/common.py
@@ -5,6 +5,7 @@ sway = False
 i3 = None
 
 outputs = {}
+mon_desc2output_name = {}  # {'Samsung Electric Company SyncMaster 0x4B493234': 'HDMI-A-1', (...)}
 outputs_num = 0
 windows_list = []
 h_taskbars_list = []

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -4349,7 +4349,7 @@ def main():
         tree = i3.get_tree()
 
     global outputs
-    outputs, mon_desc2output_name = list_outputs(sway=sway, tree=tree)
+    outputs, mon_desc2output_name = list_outputs(sway=sway)
 
     global selector_window
     selector_window = PanelSelector()

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -963,8 +963,6 @@ class EditorWrapper(object):
         for key in mon_desc2output_name:
             self.cb_monitor.append(key, key)
 
-        self.cb_monitor.append("All", "All")
-
         if self.panel["monitor"] and (self.panel["monitor"] in mon_desc2output_name or self.panel["monitor"] == "All"):
             self.cb_monitor.set_active_id(self.panel["monitor"])
 
@@ -4372,8 +4370,8 @@ def main():
             print("'python-i3ipc' package required on sway, terminating")
             sys.exit(1)
 
-        i3 = Connection()
-        tree = i3.get_tree()
+        # i3 = Connection()
+        # tree = i3.get_tree()
 
     global outputs, mon_desc2output_name
     outputs, mon_desc2output_name = list_outputs(sway=sway)

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -536,6 +536,11 @@ class PanelSelector(Gtk.Window):
 
                 ivbox.pack_start(hbox, False, False, 3)
 
+                target = panel["output"] if panel["output"] else panel["monitor"]
+
+                label = Gtk.Label()
+                label.set_markup(f"{voc['panel']}: <b>{panel['name']}</b>\tOut: {target}")
+
                 label = Gtk.Label()
                 label.set_markup("{}: '<b>{}</b>'".format(voc["panel"], panel["name"]))
                 label.set_halign(Gtk.Align.START)
@@ -543,7 +548,12 @@ class PanelSelector(Gtk.Window):
 
                 label = Gtk.Label()
                 target = panel["output"] if panel["output"] else panel["monitor"]
-                label.set_markup("{}/{}: <b>{}</b>".format(voc["output"], voc["monitor"], target))
+                if panel['output']:
+                    label.set_markup("{}: {}".format(voc["output"], panel["output"]))
+                elif panel['monitor']:
+                    label.set_markup("{}: <small>{}</small>".format(voc["output"], panel["monitor"]))
+                else:
+                    label.set_markup("{}: {}".format(voc["output"], voc['undefined']))
                 label.set_halign(Gtk.Align.START)
                 lbl_box.pack_start(label, True, True, 6)
 

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -4364,15 +4364,6 @@ def main():
     check_commands()
     load_vocabulary()
 
-    if sway:
-        try:
-            from i3ipc import Connection
-        except ModuleNotFoundError:
-            print("'python-i3ipc' package required on sway, terminating")
-            sys.exit(1)
-
-        common.i3 = Connection()
-
     global outputs, mon_desc2output_name
     outputs, mon_desc2output_name = list_outputs(sway=sway)
 

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -520,7 +520,7 @@ class PanelSelector(Gtk.Window):
             panels = configs[path]
             panel_idx = 0
             for panel in panels:
-                for item in ["name", "output", "position"]:
+                for item in ["name", "output", "monitor", "position"]:
                     check_key(panel, item, "")
                 listbox = Gtk.ListBox()
                 listbox.set_selection_mode(Gtk.SelectionMode.NONE)
@@ -542,7 +542,8 @@ class PanelSelector(Gtk.Window):
                 lbl_box.pack_start(label, True, True, 6)
 
                 label = Gtk.Label()
-                label.set_markup("{}: <b>{}</b>".format(voc["output"], panel["output"]))
+                target = panel["output"] if panel["output"] else panel["monitor"]
+                label.set_markup("{}/{}: <b>{}</b>".format(voc["output"], voc["monitor"], target))
                 label.set_halign(Gtk.Align.START)
                 lbl_box.pack_start(label, True, True, 6)
 

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -4349,7 +4349,7 @@ def main():
         tree = i3.get_tree()
 
     global outputs
-    outputs = list_outputs(sway=sway, tree=tree)
+    outputs, mon_desc2output_name = list_outputs(sway=sway, tree=tree)
 
     global selector_window
     selector_window = PanelSelector()

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -49,6 +49,7 @@ configs = {}
 editor = None
 selector_window = None
 outputs = {}
+mon_desc2output_name = {}
 
 voc = {}
 shell_data = load_shell_data()
@@ -252,6 +253,10 @@ SKELETON_PANEL: dict = {
     }
 }
 
+
+def clear_active_id(combo, target_combo):
+    if combo.get_active_id():
+        target_combo.set_active_id("")
 
 def load_vocabulary():
     global voc
@@ -822,6 +827,7 @@ class EditorWrapper(object):
 
         self.eb_name = None
         self.cb_output = None
+        self.cb_monitor = None
         self.cb_position = None
         self.cb_controls = None
         self.cb_layer = None
@@ -875,6 +881,7 @@ class EditorWrapper(object):
         defaults = {
             "name": "",
             "output": "",
+            "monitor": "",
             "layer": "bottom",
             "position": "top",
             "controls": "off",
@@ -909,6 +916,7 @@ class EditorWrapper(object):
 
         builder.get_object("lbl-panel-name").set_text("{}:".format(voc["panel-name"]))
         builder.get_object("lbl-output").set_text("{}:".format(voc["output"]))
+        builder.get_object("lbl-monitor").set_text("{}:".format(voc["monitor"]))
         builder.get_object("lbl-position").set_text("{}:".format(voc["position"]))
         builder.get_object("lbl-layer").set_text("{}:".format(voc["layer"]))
         builder.get_object("lbl-controls").set_text("{}:".format(voc["controls"]))
@@ -936,6 +944,7 @@ class EditorWrapper(object):
         self.eb_name.connect("changed", validate_name)
 
         self.cb_output = builder.get_object("output")
+        self.cb_output.append("", "")
         for key in outputs:
             self.cb_output.append(key, key)
 
@@ -948,6 +957,19 @@ class EditorWrapper(object):
         if self.cb_output.get_active_id() and self.cb_output.get_active_id() in outputs:
             screen_width = outputs[self.cb_output.get_active_id()]["width"]
             screen_height = outputs[self.cb_output.get_active_id()]["height"]
+
+        self.cb_monitor = builder.get_object("monitor")
+        self.cb_monitor.append("", "")
+        for key in mon_desc2output_name:
+            self.cb_monitor.append(key, key)
+
+        self.cb_monitor.append("All", "All")
+
+        self.cb_output.connect("changed", clear_active_id, self.cb_monitor)
+        self.cb_monitor.connect("changed", clear_active_id,self.cb_output)
+
+        if self.panel["output"] and (self.panel["output"] in outputs or self.panel["output"] == "All"):
+            self.cb_output.set_active_id(self.panel["output"])
 
         self.cb_position = builder.get_object("position")
         self.cb_position.set_active_id(self.panel["position"])
@@ -1087,8 +1109,10 @@ class EditorWrapper(object):
             self.panel["name"] = val
 
         val = self.cb_output.get_active_id()
-        if val:
-            self.panel["output"] = val
+        self.panel["output"] = val if val else ""
+
+        val = self.cb_monitor.get_active_id()
+        self.panel["monitor"] = val if val else ""
 
         val = self.cb_position.get_active_id()
         if val:
@@ -4348,7 +4372,7 @@ def main():
         i3 = Connection()
         tree = i3.get_tree()
 
-    global outputs
+    global outputs, mon_desc2output_name
     outputs, mon_desc2output_name = list_outputs(sway=sway)
 
     global selector_window

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -965,6 +965,9 @@ class EditorWrapper(object):
 
         self.cb_monitor.append("All", "All")
 
+        if self.panel["monitor"] and (self.panel["monitor"] in mon_desc2output_name or self.panel["monitor"] == "All"):
+            self.cb_monitor.set_active_id(self.panel["monitor"])
+
         self.cb_output.connect("changed", clear_active_id, self.cb_monitor)
         self.cb_monitor.connect("changed", clear_active_id,self.cb_output)
 

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -15,6 +15,8 @@ from gi.repository import Gtk, Gdk, GLib
 from nwg_panel.tools import get_config_dir, local_dir, load_json, save_json, load_string, list_outputs, check_key, \
     list_configs, update_gtk_entry, is_command, check_commands, cmd2string, eprint, temp_dir, load_shell_data, hyprctl
 
+from nwg_panel import common
+
 from nwg_panel.__about__ import __version__
 
 dir_name = os.path.dirname(__file__)
@@ -4362,7 +4364,6 @@ def main():
     check_commands()
     load_vocabulary()
 
-    tree = None
     if sway:
         try:
             from i3ipc import Connection
@@ -4370,8 +4371,7 @@ def main():
             print("'python-i3ipc' package required on sway, terminating")
             sys.exit(1)
 
-        # i3 = Connection()
-        # tree = i3.get_tree()
+        common.i3 = Connection()
 
     global outputs, mon_desc2output_name
     outputs, mon_desc2output_name = list_outputs(sway=sway)

--- a/nwg_panel/glade/config_panel.glade
+++ b/nwg_panel/glade/config_panel.glade
@@ -8,7 +8,7 @@
     <property name="label-xalign">0.5</property>
     <property name="shadow-type">out</property>
     <child>
-      <!-- n-columns=3 n-rows=17 -->
+      <!-- n-columns=4 n-rows=18 -->
       <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -54,317 +54,6 @@
           </packing>
         </child>
         <child>
-          <object class="GtkComboBoxText" id="position">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <items>
-              <item id="top" translatable="yes">top</item>
-              <item id="bottom" translatable="yes">bottom</item>
-              <item id="left" translatable="yes">left</item>
-              <item id="right" translatable="yes">right</item>
-            </items>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-position">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Position:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="layer">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <items>
-              <item id="background" translatable="yes">background</item>
-              <item id="bottom" translatable="yes">bottom</item>
-              <item id="top" translatable="yes">top</item>
-              <item id="overlay" translatable="yes">overlay</item>
-            </items>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-layer">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Layer:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="controls">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <items>
-              <item id="right" translatable="yes">end</item>
-              <item id="left" translatable="yes">start</item>
-              <item id="off" translatable="yes">off</item>
-            </items>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-controls">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Controls:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-css-name">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">CSS name:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">14</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkEntry" id="css-name">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">20</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">14</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-icon-set">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Icon set:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">13</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="icons">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <items>
-              <item id="light" translatable="yes">custom light</item>
-              <item id="dark" translatable="yes">custom dark</item>
-              <item id="gtk" translatable="yes">GTK</item>
-            </items>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">13</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-spacing">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Spacing:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">12</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="spacing">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">4</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">12</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-vertical-padding">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Vertical padding:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">11</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="padding-vertical">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">4</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">11</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-horizontal-padding">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Horizontal padding</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">10</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="padding-horizontal">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">4</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">10</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-bottom-margin">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Bottom margin:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">9</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="margin-bottom">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">4</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">9</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-top-margin">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Top margin:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">8</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="margin-top">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">4</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">8</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-height">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Height:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">7</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="height">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="max-length">4</property>
-            <property name="width-chars">4</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">7</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-width">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Width:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">6</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-menu-start">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="label" translatable="yes">Menu Start:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="menu">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <items>
-              <item id="left" translatable="yes">on the left</item>
-              <item id="right" translatable="yes">on the right</item>
-              <item id="off" translatable="yes">off</item>
-            </items>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">5</property>
-          </packing>
-        </child>
-        <child>
           <object class="GtkLabel" id="lbl-panel-name">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -387,7 +76,7 @@
           </object>
           <packing>
             <property name="left-attach">1</property>
-            <property name="top-attach">16</property>
+            <property name="top-attach">17</property>
           </packing>
         </child>
         <child>
@@ -401,65 +90,7 @@
           </object>
           <packing>
             <property name="left-attach">0</property>
-            <property name="top-attach">16</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="lbl-hide-show-signal">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Hide/show signal:</property>
-          </object>
-          <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">15</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="width-auto">
-            <property name="label" translatable="yes">auto</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">6</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="width">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="width-chars">4</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">6</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="sigrt">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">15</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkCheckButton" id="use-sigrt">
-            <property name="label" translatable="yes">use signal</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">15</property>
+            <property name="top-attach">17</property>
           </packing>
         </child>
         <child>
@@ -472,8 +103,453 @@
           </object>
           <packing>
             <property name="left-attach">3</property>
+            <property name="top-attach">16</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="use-sigrt">
+            <property name="label" translatable="yes">use signal</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">16</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="sigrt">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">16</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-hide-show-signal">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Hide/show signal:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">16</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="css-name">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">20</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
             <property name="top-attach">15</property>
           </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-css-name">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">CSS name:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">15</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="icons">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <items>
+              <item id="light" translatable="yes">custom light</item>
+              <item id="dark" translatable="yes">custom dark</item>
+              <item id="gtk" translatable="yes">GTK</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">14</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-icon-set">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Icon set:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">14</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="spacing">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">4</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">13</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-spacing">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Spacing:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">13</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="padding-vertical">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">4</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">12</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-vertical-padding">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Vertical padding:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">12</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="padding-horizontal">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">4</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">11</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-horizontal-padding">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Horizontal padding</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">11</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="margin-bottom">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">4</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">10</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-bottom-margin">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Bottom margin:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">10</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="margin-top">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">4</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">9</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-top-margin">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Top margin:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">9</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="height">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="max-length">4</property>
+            <property name="width-chars">4</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-height">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Height:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="width">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="width-chars">4</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">7</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-width">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Width:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">7</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="width-auto">
+            <property name="label" translatable="yes">auto</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">7</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="menu">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <items>
+              <item id="left" translatable="yes">on the left</item>
+              <item id="right" translatable="yes">on the right</item>
+              <item id="off" translatable="yes">off</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-menu-start">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Menu Start:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="controls">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <items>
+              <item id="right" translatable="yes">end</item>
+              <item id="left" translatable="yes">start</item>
+              <item id="off" translatable="yes">off</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-controls">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Controls:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="layer">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <items>
+              <item id="background" translatable="yes">background</item>
+              <item id="bottom" translatable="yes">bottom</item>
+              <item id="top" translatable="yes">top</item>
+              <item id="overlay" translatable="yes">overlay</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-layer">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Layer:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="position">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <items>
+              <item id="top" translatable="yes">top</item>
+              <item id="bottom" translatable="yes">bottom</item>
+              <item id="left" translatable="yes">left</item>
+              <item id="right" translatable="yes">right</item>
+            </items>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-position">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Position:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl-monitor">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">Monitor:</property>
+          </object>
+          <packing>
+            <property name="left-attach">0</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkComboBoxText" id="monitor">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/langs/en_US.json
+++ b/nwg_panel/langs/en_US.json
@@ -252,6 +252,7 @@
   "top-margin": "Top margin",
   "tray": "Tray",
   "turned-on": "Turned on",
+  "undefined": "Undefined",
   "units": "Units",
   "use-signal": "Use signal",
   "user-menu": "User menu",

--- a/nwg_panel/langs/en_US.json
+++ b/nwg_panel/langs/en_US.json
@@ -132,6 +132,7 @@
   "modules-center": "Modules center",
   "modules-left": "Modules left",
   "modules-right": "Modules right",
+  "monitor": "Monitor",
   "move-down": "move down",
   "move-up": "move up",
   "name": "Name",

--- a/nwg_panel/langs/pl_PL.json
+++ b/nwg_panel/langs/pl_PL.json
@@ -132,6 +132,7 @@
   "modules-center": "Moduły środkowe",
   "modules-left": "Moduły lewe",
   "modules-right": "Moduły prawe",
+  "monitor": "Monitor",
   "move-down": "przesuń w dół",
   "move-up": "przesuń w górę",
   "name": "Nazwa",

--- a/nwg_panel/langs/pl_PL.json
+++ b/nwg_panel/langs/pl_PL.json
@@ -252,6 +252,7 @@
   "top-margin": "Margines górny",
   "tray": "Tacka systemowa",
   "turned-on": "Włączony",
+  "undefined": "Niezdefiniowany",
   "units": "Jednostki",
   "use-signal": "Używaj sygnału",
   "user-menu": "Menu użytkownika",

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -543,7 +543,7 @@ def main():
     copy_files(os.path.join(dir_name, "local"), local_dir())
 
     tree = common.i3.get_tree() if sway else None
-    common.outputs = list_outputs(sway=sway, tree=tree)
+    common.outputs, common.mon_desc2output_name = list_outputs(sway=sway, tree=tree)
 
     panels = load_json(config_file)
 
@@ -835,7 +835,7 @@ def main():
     if sway:
         common.outputs_num = num_active_outputs(common.i3.get_outputs())
     else:
-        common.outputs = list_outputs(sway=sway, tree=tree, silent=True)
+        common.outputs, common.mon_desc2output_name = list_outputs(sway=sway, tree=tree, silent=True)
         common.outputs_num = len(common.outputs)
 
     if sway:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -545,7 +545,7 @@ def main():
     # tree = common.i3.get_tree() if sway else None
     common.outputs, common.mon_desc2output_name = list_outputs(sway=sway)
     print(f"Outputs: {common.outputs}")
-    print(f"Description->output name: {common.mon_desc2output_name}")
+    print(f"Descriptions: {common.mon_desc2output_name}")
 
     panels = load_json(config_file)
 
@@ -571,7 +571,6 @@ def main():
         check_key(panel, "monitor", "")
         if panel["monitor"]:
             panel["output"] = common.mon_desc2output_name[panel["monitor"]]
-            print(f"Panel output '{panel["output"]}' assigned on the basis of panel monitor '{panel['monitor']}'")
 
         clones = []
         if panel["output"] == "All" and len(common.outputs) >= 1:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -542,8 +542,10 @@ def main():
     copy_files(os.path.join(dir_name, "config"), common.config_dir, args.restore)
     copy_files(os.path.join(dir_name, "local"), local_dir())
 
-    tree = common.i3.get_tree() if sway else None
-    common.outputs, common.mon_desc2output_name = list_outputs(sway=sway, tree=tree)
+    # tree = common.i3.get_tree() if sway else None
+    common.outputs, common.mon_desc2output_name = list_outputs(sway=sway)
+    print(f"Outputs: {common.outputs}")
+    print(f"Description->output name: {common.mon_desc2output_name}")
 
     panels = load_json(config_file)
 
@@ -835,7 +837,7 @@ def main():
     if sway:
         common.outputs_num = num_active_outputs(common.i3.get_outputs())
     else:
-        common.outputs, common.mon_desc2output_name = list_outputs(sway=sway, tree=tree, silent=True)
+        common.outputs, common.mon_desc2output_name = list_outputs(sway=sway, silent=True)
         common.outputs_num = len(common.outputs)
 
     if sway:

--- a/nwg_panel/main.py
+++ b/nwg_panel/main.py
@@ -568,6 +568,10 @@ def main():
     to_append = []
     for panel in panels:
         check_key(panel, "output", "")
+        check_key(panel, "monitor", "")
+        if panel["monitor"]:
+            panel["output"] = common.mon_desc2output_name[panel["monitor"]]
+            print(f"Panel output '{panel["output"]}' assigned on the basis of panel monitor '{panel['monitor']}'")
 
         clones = []
         if panel["output"] == "All" and len(common.outputs) >= 1:
@@ -789,11 +793,13 @@ def main():
 
             check_key(panel, "layer", "top")
             o = panel["output"] if "output" in panel else "undefined"
-            print("Panel '{}': output: {}, position: {}, layer: {}, width: {}, height: {}".format(panel["name"], o,
-                                                                                                  panel["position"],
-                                                                                                  panel["layer"],
-                                                                                                  panel["width"],
-                                                                                                  panel["height"]))
+            m = panel["monitor"] if "monitor" in panel else "undefined"
+            print("Panel '{}': output: {}, monitor: {}, position: {}, layer: {}, width: {}, height: {}".format(
+                panel["name"], o, m,
+                panel["position"],
+                panel["layer"],
+                panel["width"],
+                panel["height"]))
 
             if monitor:
                 GtkLayerShell.set_monitor(window, monitor)

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -307,6 +307,7 @@ def list_outputs(sway=False, tree=None, silent=False):
                                           "y": item["y"],
                                           "width": int(item["width"] / item["scale"]),
                                           "height": int(item["height"] / item["scale"]),
+                                          "description": item["description"],
                                           "monitor": None}
             # swap for rotated displays
             if item["transform"] in [1, 3, 5, 7]:
@@ -378,7 +379,12 @@ def list_outputs(sway=False, tree=None, silent=False):
     for key, monitor in zip(outputs_dict.keys(), monitors):
         outputs_dict[key]["monitor"] = monitor
 
-    return outputs_dict
+    # map monitor descriptions to output names
+    mon_desc2output_name = {}
+    for key in outputs_dict:
+        mon_desc2output_name[outputs_dict[key]["description"]] = key if "description" in outputs_dict[key] else ""
+
+    return outputs_dict, mon_desc2output_name
 
 
 def check_key(dictionary, key, default_value):

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -284,9 +284,18 @@ def list_outputs(sway=False, silent=False):
     """
     outputs_dict = {}
     if sway:
+        if sway:
+            try:
+                from i3ipc import Connection
+            except ModuleNotFoundError:
+                print("'python-i3ipc' package required on sway, terminating")
+                sys.exit(1)
+
+            i3 = Connection()
+
         if not silent:
             print("Running on sway")
-        outputs = nwg_panel.common.i3.get_outputs()
+        outputs = i3.get_outputs()
         for item in outputs:
             outputs_dict[item.name] = {"x": item.rect.x,
                                        "y": item.rect.y,

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -927,10 +927,11 @@ def cmd_through_compositor(cmd):
     common_settings = load_json(cs_file)
     if "run-through-compositor" not in common_settings or common_settings["run-through-compositor"] :
         if os.getenv("SWAYSOCK"):
-            cmd = f"swaymsg exec '{cmd}'"
+            cmd = f'swaymsg exec "{cmd}"'
         elif os.getenv("HYPRLAND_INSTANCE_SIGNATURE"):
-            cmd = f"hyprctl dispatch exec '{cmd}'"
+            cmd = f'hyprctl dispatch exec "{cmd}"'
     return cmd
+
 
 def load_resource(package, resource_name):
     try:

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -299,9 +299,9 @@ def list_outputs(sway=False, silent=False):
         if not silent:
             print("Running on Hyprland")
         cmd = "hyprctl -j monitors"
-        output = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
-        monitors = json.loads(output)
-        for item in monitors:
+        result = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
+        outputs = json.loads(result)
+        for item in outputs:
             outputs_dict[item["name"]] = {"x": item["x"],
                                           "y": item["y"],
                                           "width": int(item["width"] / item["scale"]),
@@ -361,9 +361,9 @@ def list_outputs(sway=False, silent=False):
                                                   'description': description,
                                                   'scale': scale,
                                                   'monitor': None}
-                        #Each monitor only have a single transform this avoid parsing multiple times the same monitor
-                        #Disabled monitors don't have transforms.
-                        # Gdk doesn't report disabled monitor, not filtering them would cause crashes
+                        # Each monitor only has a single transform, this is to avoid parsing the same monitor multiple times
+                        # Disabled monitors don't have transforms.
+                        # Gdk doesn't report disabled monitors, not filtering them would cause crashes
                         transform = None
         else:
             print("'wlr-randr' command not found, terminating")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(f_name):
 
 setup(
     name='nwg-panel',
-    version='0.9.41',
+    version='0.9.42',
     description='GTK3-based panel for sway and Hyprland Wayland compositors',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- Allowed assignment of panel to monitor based on the description (`f"{make} {model} {serial}"` on sway, `"description"` on Hyprland), instead of the output name; closes #325;
- reformatted `cmd_through_compositor(cmd)` function output; hopefully closes #326.