### PR TITLE
Add support for using miraclemsg when miracle-wm is detected

### DIFF
--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -930,7 +930,10 @@ def cmd_through_compositor(cmd):
     common_settings = load_json(cs_file)
     if "run-through-compositor" not in common_settings or common_settings["run-through-compositor"] :
         if os.getenv("SWAYSOCK"):
-            cmd = f'swaymsg exec "{cmd}"'
+            if os.getenv("XDG_SESSION_DESKTOP") == "miracle-wm":
+                cmd = f'miraclemsg exec "{cmd}"'
+            else:
+                cmd = f'swaymsg exec "{cmd}"'
         elif os.getenv("HYPRLAND_INSTANCE_SIGNATURE"):
             cmd = f'hyprctl dispatch exec "{cmd}"'
     return cmd


### PR DESCRIPTION
Miracle-WM is just like Sway except it has its own preferred binary for sending Sway-style messages.