### PR TITLE
Fix tray icon for electron apps that change the IconThemePath

### DIFF
--- a/nwg_panel/modules/sni_system_tray/item.py
+++ b/nwg_panel/modules/sni_system_tray/item.py
@@ -81,7 +81,7 @@ class StatusNotifierItem(object):
             )
         if hasattr(self.item_proxy, 'NewIcon'):
             self.item_proxy.NewIcon.connect(
-                lambda: self.change_handler(["IconName", "IconPixmap"])
+                lambda: self.change_handler(["IconName", "IconPixmap", "IconThemePath"])
             )
         if hasattr(self.item_proxy, 'NewAttentionIcon'):
             self.item_proxy.NewAttentionIcon.connect(


### PR DESCRIPTION
Electron apps use /tmp/.org.chromium.Chromium.XXXX as the theme path and the last part can change dynamically. This commit adds IconThemePath as a property to update when handling NewIcon.

You can test this with [teams-for-linux](https://aur.archlinux.org/packages/teams-for-linux-bin). Without this fix, tray module cannot find the icon and displays `icon-missing` instead of the correct tray icon.