### PR TITLE
Fix tray icon when IconThemePath exists but is empty

### DIFF
--- a/nwg_panel/modules/sni_system_tray/tray.py
+++ b/nwg_panel/modules/sni_system_tray/tray.py
@@ -166,11 +166,13 @@ class Tray(Gtk.EventBox):
         event_box = self.items[full_service_name]["event_box"]
         image = self.items[full_service_name]["image"]
 
-        if "IconThemePath" in changed_properties or ("IconName" in changed_properties and len(item.properties['IconName']) > 0):
+        def prop_changed(prop):
+            return prop in changed_properties and len(item.properties[prop]) > 0
+
+        if prop_changed("IconThemePath") or prop_changed("IconName"):
             update_icon(image, item, self.icon_size, self.icons_path)
-        elif "IconPixmap" in changed_properties and len(item.properties["IconPixmap"]) != 0:
+        elif prop_changed("IconPixmap"):
             update_icon_from_pixmap(image, item, self.icon_size)
-            pass
 
         if "Tooltip" in changed_properties or "ToolTip" in changed_properties:
             update_tooltip(image, item)


### PR DESCRIPTION
It seems that my change in #362 caused a different bug. My bad, I should have done more testing.

Now that the IconThemePath is updated in `item.py`, sometimes it exists but is an empty string. The conditional in `tray.py` checks for empty strings in IconName and IconPixmap, but not IconThemePath, so I just added that check.

The diff is larger because line 169 (currently 172) looked a bit messy after adding the condition, so I preferred extracting the check to a function. Feel free to inline it if you don't like nested functions.