### PR TITLE
Hide special workspaces in hyprland workspaces, and changes to hyprland taskbar

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -138,7 +138,6 @@ SKELETON_PANEL: dict = {
         "show-app-name": True,
         "all-workspaces": True,
         "show-workspace": True,
-        "show-inactive-workspaces": True,
         "show-layout": True,
         "all-outputs": False,
         "mark-xwayland": True,
@@ -1500,7 +1499,6 @@ class EditorWrapper(object):
             "show-app-name": True,
             "show-app-name-special": False,
             "show-workspace": True,
-            "show-inactive-workspaces": True,
             "all-workspaces": True,
             "show-layout": True,
             "all-outputs": False,
@@ -1556,10 +1554,6 @@ class EditorWrapper(object):
         self.ckb_show_workspace.set_label(voc["show-workspaces"])
         self.ckb_show_workspace.set_active(settings["show-workspace"])
 
-        self.ckb_show_inactive_workspaces = builder.get_object("show-inactive-workspaces")
-        self.ckb_show_inactive_workspaces.set_label(voc["show-inactive-workspaces"])
-        self.ckb_show_inactive_workspaces.set_active(settings["show-inactive-workspaces"])
-
         self.ckb_all_workspaces = builder.get_object("all-workspaces")
         self.ckb_all_workspaces.set_label(voc["all-workspaces"])
         self.ckb_all_workspaces.set_active(settings["all-workspaces"])
@@ -1611,7 +1605,6 @@ class EditorWrapper(object):
         settings["show-app-name"] = self.ckb_show_app_name.get_active()
         settings["show-workspace"] = self.ckb_show_workspace.get_active()
         settings["all-workspaces"] = self.ckb_all_workspaces.get_active()
-        settings["show-inactive-workspaces"] = self.ckb_show_inactive_workspaces.get_active()
         settings["show-app-name-special"] = self.ckb_show_app_name_special.get_active()
         settings["show-layout"] = self.ckb_show_layout.get_active()
         settings["mark-xwayland"] = self.ckb_mark_xwayland.get_active()

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -138,6 +138,7 @@ SKELETON_PANEL: dict = {
         "show-app-name": True,
         "all-workspaces": True,
         "show-workspace": True,
+        "show-inactive-workspaces": True,
         "show-layout": True,
         "all-outputs": False,
         "mark-xwayland": True,
@@ -1499,6 +1500,7 @@ class EditorWrapper(object):
             "show-app-name": True,
             "show-app-name-special": False,
             "show-workspace": True,
+            "show-inactive-workspaces": True,
             "all-workspaces": True,
             "show-layout": True,
             "all-outputs": False,
@@ -1554,6 +1556,10 @@ class EditorWrapper(object):
         self.ckb_show_workspace.set_label(voc["show-workspaces"])
         self.ckb_show_workspace.set_active(settings["show-workspace"])
 
+        self.ckb_show_inactive_workspaces = builder.get_object("show-inactive-workspaces")
+        self.ckb_show_inactive_workspaces.set_label(voc["show-inactive-workspaces"])
+        self.ckb_show_inactive_workspaces.set_active(settings["show-inactive-workspaces"])
+
         self.ckb_all_workspaces = builder.get_object("all-workspaces")
         self.ckb_all_workspaces.set_label(voc["all-workspaces"])
         self.ckb_all_workspaces.set_active(settings["all-workspaces"])
@@ -1605,6 +1611,7 @@ class EditorWrapper(object):
         settings["show-app-name"] = self.ckb_show_app_name.get_active()
         settings["show-workspace"] = self.ckb_show_workspace.get_active()
         settings["all-workspaces"] = self.ckb_all_workspaces.get_active()
+        settings["show-inactive-workspaces"] = self.ckb_show_inactive_workspaces.get_active()
         settings["show-app-name-special"] = self.ckb_show_app_name_special.get_active()
         settings["show-layout"] = self.ckb_show_layout.get_active()
         settings["mark-xwayland"] = self.ckb_mark_xwayland.get_active()

--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -136,6 +136,8 @@ SKELETON_PANEL: dict = {
         "client-padding": 0,
         "show-app-icon": True,
         "show-app-name": True,
+        "all-workspaces": True,
+        "show-workspace": True,
         "show-layout": True,
         "all-outputs": False,
         "mark-xwayland": True,
@@ -1496,6 +1498,8 @@ class EditorWrapper(object):
             "show-app-icon": True,
             "show-app-name": True,
             "show-app-name-special": False,
+            "show-workspace": True,
+            "all-workspaces": True,
             "show-layout": True,
             "all-outputs": False,
             "mark-xwayland": True,
@@ -1546,6 +1550,14 @@ class EditorWrapper(object):
         self.ckb_show_app_name.set_label(voc["show-name"])
         self.ckb_show_app_name.set_active(settings["show-app-name"])
 
+        self.ckb_show_workspace = builder.get_object("show-workspace")
+        self.ckb_show_workspace.set_label(voc["show-workspaces"])
+        self.ckb_show_workspace.set_active(settings["show-workspace"])
+
+        self.ckb_all_workspaces = builder.get_object("all-workspaces")
+        self.ckb_all_workspaces.set_label(voc["all-workspaces"])
+        self.ckb_all_workspaces.set_active(settings["all-workspaces"])
+
         self.ckb_show_app_name_special = builder.get_object("show-app-name-special")
         self.ckb_show_app_name_special.set_label(voc["show-name-on-special"])
         self.ckb_show_app_name_special.set_active(settings["show-app-name-special"])
@@ -1591,6 +1603,8 @@ class EditorWrapper(object):
 
         settings["show-app-icon"] = self.ckb_show_app_icon.get_active()
         settings["show-app-name"] = self.ckb_show_app_name.get_active()
+        settings["show-workspace"] = self.ckb_show_workspace.get_active()
+        settings["all-workspaces"] = self.ckb_all_workspaces.get_active()
         settings["show-app-name-special"] = self.ckb_show_app_name_special.get_active()
         settings["show-layout"] = self.ckb_show_layout.get_active()
         settings["mark-xwayland"] = self.ckb_mark_xwayland.get_active()

--- a/nwg_panel/glade/config_hyprland_taskbar.glade
+++ b/nwg_panel/glade/config_hyprland_taskbar.glade
@@ -264,28 +264,6 @@ the horizontal, in degrees, measured counterclockwise</property>
           </packing>
         </child>
         <child>
-          <object class="GtkCheckButton" id="show-inactive-workspaces">
-            <property name="label" translatable="yes">Show inactive workspaces</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="draw-indicator">True</property>
-          </object>
-          <packing>
-            <property name="left-attach">2</property>
-            <property name="top-attach">7</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
           <placeholder/>
         </child>
         <child>

--- a/nwg_panel/glade/config_hyprland_taskbar.glade
+++ b/nwg_panel/glade/config_hyprland_taskbar.glade
@@ -8,7 +8,7 @@
     <property name="label-xalign">0.5</property>
     <property name="shadow-type">out</property>
     <child>
-      <!-- n-columns=3 n-rows=10 -->
+      <!-- n-columns=4 n-rows=10 -->
       <object class="GtkGrid" id="grid">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
@@ -262,6 +262,43 @@ the horizontal, in degrees, measured counterclockwise</property>
             <property name="left-attach">1</property>
             <property name="top-attach">6</property>
           </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="show-inactive-workspaces">
+            <property name="label" translatable="yes">Show inactive workspaces</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">7</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <placeholder/>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/glade/config_hyprland_taskbar.glade
+++ b/nwg_panel/glade/config_hyprland_taskbar.glade
@@ -187,8 +187,8 @@
             <property name="draw-indicator">True</property>
           </object>
           <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">6</property>
+            <property name="left-attach">2</property>
+            <property name="top-attach">5</property>
             <property name="width">2</property>
           </packing>
         </child>
@@ -238,7 +238,30 @@ the horizontal, in degrees, measured counterclockwise</property>
           </packing>
         </child>
         <child>
-          <placeholder/>
+          <object class="GtkCheckButton" id="all-workspaces">
+            <property name="label" translatable="yes">All workspaces</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="show-workspace">
+            <property name="label" translatable="yes">Show workspace</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="left-attach">1</property>
+            <property name="top-attach">6</property>
+          </packing>
         </child>
         <child>
           <placeholder/>

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -70,6 +70,7 @@ class HyprlandWorkspaces(Gtk.Box):
             for ws in workspaces:
                 if (
                         (self.settings["show-workspaces-from-all-outputs"] or ws["monitor"] == self.monitor_name)
+                        and ws["id"] > 0 # filter special workspaces
                         and ws["id"] not in self.ws_nums
                 ):
                     self.ws_nums.append(ws["id"])
@@ -171,7 +172,8 @@ class HyprlandWorkspaces(Gtk.Box):
             # Updating occupied workspaces
             for ws in workspaces:
                 # add workspaces to the list if not already there, important for example when monitor is unplugged
-                if ws["id"] not in self.ws_nums:
+                if (ws["id"] > 0 # filter special workspaces
+                    and ws["id"] not in self.ws_nums):
                     self.ws_nums.append(ws["id"])
 
                 for client in clients:  # check for all occupied workspaces

--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -2,7 +2,7 @@
 
 from gi.repository import Gtk, Gdk
 
-from nwg_panel.tools import update_image_fallback_desktop, hyprctl, h_list_workspace_rules
+from nwg_panel.tools import update_image_fallback_desktop, hyprctl, h_list_workspace_rules, is_hyprland_workspace_rule_valid
 
 
 class HyprlandWorkspaces(Gtk.Box):
@@ -55,7 +55,7 @@ class HyprlandWorkspaces(Gtk.Box):
             self.pack_start(self.num_box, False, False, 0)
 
             # read workspaces from workspace rules
-            ws_rules = [rule for rule in h_list_workspace_rules() if self.is_workspace_rule_valid(rule)]
+            ws_rules = [rule for rule in h_list_workspace_rules() if is_hyprland_workspace_rule_valid(rule)]
             workspace_rules = []
             for ws in ws_rules:
                 if self.settings["show-workspaces-from-all-outputs"] or ws["monitor"] == self.monitor_name:
@@ -121,18 +121,6 @@ class HyprlandWorkspaces(Gtk.Box):
         box.pack_start(lbl, False, False, 6)
 
         return eb, lbl
-    
-    def is_workspace_rule_valid(self, ws_rule):
-        """Check if the workspace rule is defining a workspace and binding it to a monitor. If not, return False.
-        This is specific to identify nwg-panel workspace rules.
-        """
-        try:
-            int(ws_rule["workspaceString"]) # since we are only supporting workspace ids, and not workspaces defined by names
-            if "monitor" in ws_rule:
-                return True
-            return False
-        except:
-            return False
 
     def choose_workspace_ids_around_active(self, workspace_ids, active_ws_id):
         # choose workspaces around the active workspace

--- a/nwg_panel/tools.py
+++ b/nwg_panel/tools.py
@@ -29,6 +29,17 @@ try:
 except:
     pass
 
+def is_hyprland_workspace_rule_valid(ws_rule):
+    """Check if the workspace rule is defining a workspace and binding it to a monitor. If not, return False.
+    This is specific to identify nwg-panel workspace rules.
+    """
+    try:
+        int(ws_rule["workspaceString"]) # since we are only supporting workspace ids, and not workspaces defined by names
+        if "monitor" in ws_rule and int(ws_rule["workspaceString"]) > 0:
+            return True
+        return False
+    except:
+        return False
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)


### PR DESCRIPTION
- Fix bug #380 in hyprland workspaces
- Make following changes to hyprland taskbar
-- Add options `all-workspaces` and `show-workspace` to make it possible to hide workspaces and limit clients to current workspace.
-- ~The context menu for clients now shows existing workspaces, than just a list of 1-10. Any other inactive workspaces are also listed if the setting `show-inactive-workspaces` are enabled. Which is enabled by default.~