### PR TITLE
Fix Scroll Down Launching Scroll Up Command

### DIFF
--- a/nwg_panel/modules/swaync.py
+++ b/nwg_panel/modules/swaync.py
@@ -125,8 +125,8 @@ class SwayNC(Gtk.EventBox):
     def on_scroll(self, widget, event):
         if event.direction == Gdk.ScrollDirection.UP and self.settings["on-scroll-up"]:
             self.launch(self.settings["on-scroll-up"])
-        elif event.direction == Gdk.ScrollDirection.DOWN and self.settings["on-scroll-up"]:
-            self.launch(self.settings["on-scroll-up"])
+        elif event.direction == Gdk.ScrollDirection.DOWN and self.settings["on-scroll-down"]:
+            self.launch(self.settings["on-scroll-down"])
         else:
             print("No command assigned")
 


### PR DESCRIPTION
Currently setting a command for scroll down on notification icon does
not work. It will execute the scroll up command, if it is set.

This makes the scrolling down execute the scroll down command
