### PR TITLE
Patched sway-taskbar module to hide workspace numbers when all-workspaces: false is set

### DIFF
--- a/nwg_panel/config.py
+++ b/nwg_panel/config.py
@@ -1505,6 +1505,7 @@ class EditorWrapper(object):
         settings["workspace-buttons"] = self.workspace_buttons.get_active()
         settings["mark-xwayland"] = self.ckb_mark_xwayland.get_active()
         settings["all-outputs"] = self.ckb_all_outputs.get_active()
+        settings["all-workspaces"] = self.ckb_all_workspaces.get_active()
 
         try:
             settings["angle"] = float(self.sb_angle.get_active_id())

--- a/nwg_panel/modules/sway_taskbar.py
+++ b/nwg_panel/modules/sway_taskbar.py
@@ -77,14 +77,22 @@ class SwayTaskbar(Gtk.Box):
         for display in self.displays_tree:
             for desc in display.descendants():
                 if desc.type == "workspace":
-                    self.ws_box = WorkspaceBox(desc, self.settings, self.autotiling)
+                    # hide the workspace labels (WorkspaceBox) when all_workspaces is set to False
+                    if all_workspaces:
+                        self.ws_box = WorkspaceBox(desc, self.settings, self.autotiling)
                     if all_workspaces or desc.find_focused() is not None:
                         for con in desc.descendants():
                             if con.name or con.app_id:
                                 win_box = WindowBox(self.tree, con, self.settings, self.position, self.icons_path,
                                                     self.cache_file, floating=con in desc.floating_nodes)
-                                self.ws_box.pack_start(win_box, False, False, self.settings["task-padding"])
-                    self.pack_start(self.ws_box, False, False, 0)
+                                if all_workspaces:
+                                    self.ws_box.pack_start(win_box, False, False, self.settings["task-padding"])
+                                else:
+                                    # bypass WorkspaceBox to hide the labels
+                                    self.pack_start(win_box, False, False, self.settings["task-padding"])
+                    if all_workspaces:
+                        # again, omit WorkspaceBox
+                        self.pack_start(self.ws_box, False, False, 0)
         self.show_all()
 
     def on_i3ipc_event(self, i3conn, event):


### PR DESCRIPTION
Fixed a bug where the sway-taskbar module showed workspace numbers even when it was configured to show windows only from current workspace (`"all-workspaces": false`).

Let's say that there are some windows open on workspaces 1, 2, and 4. Workspace 3 is currently focused and contains 2 kitty terminals. `"all-workspaces": false` is set in the config.

Before the fix, the taskbar would show `1: 2: 3: [<kitty logo> ~] [<kitty logo> ~] 4:`
After the fix, it would show just `[<kitty logo> ~] [<kitty logo> ~]`
