### PR TITLE
fix IndexError in hyprland_workspaces when no workspace matches active id

### DIFF
--- a/nwg_panel/modules/hyprland_workspaces.py
+++ b/nwg_panel/modules/hyprland_workspaces.py
@@ -162,8 +162,9 @@ class HyprlandWorkspaces(Gtk.Box):
             focused_mon = next((m for m in monitors if m["focused"]), {"activeWorkspace": {"id": 0}})
         else:
             focused_mon = next((m for m in monitors if m["name"] == self.monitor_name), {"activeWorkspace": {"id": 0}})
-        # active workspace on the focused monitor is what we want
-        active_ws = [ws for ws in workspaces if focused_mon['activeWorkspace']["id"] == ws["id"]][0]
+        # active workspace on the focused monitor is what we want, fall back to a safe dict if nothing matches
+        active_ws = next((ws for ws in workspaces if focused_mon['activeWorkspace']["id"] == ws["id"]),
+                         {"id": 0, "lastwindow": ""})
 
         if self.settings["show-workspaces"]:
             occupied_workspaces = []  # should not be sorted, as this should be in the same order as the workspaces in Hyprland


### PR DESCRIPTION
On a `monitoradded` event Hyprland can briefly report an active workspace id that is not yet present in the workspace list, so the `[...][0]` lookup on the filtered list raises `IndexError: list index out of range` and the panel restarts (#428). This mirrors the existing `next(..., default)` fallback used a couple of lines above for `focused_mon`, returning a safe dict with the `id` and `lastwindow` keys the rest of `refresh()` reads.